### PR TITLE
Updated tag-cmdstan.sh release script to replace nightly in make/stan…

### DIFF
--- a/release-scripts/tag-cmdstan.sh
+++ b/release-scripts/tag-cmdstan.sh
@@ -174,6 +174,7 @@ print_step 4
 _msg="Updating version numbers"
 pushd $cmdstan_directory > /dev/null
 
+sed -i 's/nightly/'$version'/g' make/stanc
 replace_version $(grep -rlF "$old_version" src make makefile)
 replace_version .github/ISSUE_TEMPLATE.md
 git commit -m "release/v$version: updating version numbers" -a


### PR DESCRIPTION
… with the current release version.

https://github.com/stan-dev/ci-scripts/issues/4