### PR TITLE
Minor fixes to the non-x86 tarball builder script

### DIFF
--- a/release-scripts/build-non-x86-tarballs.sh
+++ b/release-scripts/build-non-x86-tarballs.sh
@@ -1,7 +1,14 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "ERROR: Please specify a version."
+    exit 2
+fi
+
 VERSION=$1 #should be in MAJOR.MINOR.PATCH form
 X86URL="https://github.com/stan-dev/cmdstan/releases/download/v${VERSION}/cmdstan-${VERSION}.tar.gz"
 X64TARBALL="cmdstan-${VERSION}.tar.gz"
-ARCHS=("arm64" "armel" "armhf" "mip64el" "ppc64el" "s390x")
+ARCHS=("arm64" "armel" "armhf" "mips64el" "ppc64el" "s390x")
 
 rm -Rf build
 mkdir -p build
@@ -20,7 +27,7 @@ rm cmdstan-${VERSION}/bin/*-stanc
 
 for ARCH_NAME in ${ARCHS[@]}
 do
-    mv "linux-${ARCH_NAME}-stanc" "cmdstan-${VERSION}/bin/linux-${ARCH_NAME}-stanc"
-    tar -cvf "cmdstan-${VERSION}-linux-${ARCH_NAME}.tar.gz" "cmdstan-${VERSION}"
-    rm "cmdstan-${VERSION}/bin/linux-${ARCH_NAME}-stanc"
+    mv "linux-${ARCH_NAME}-stanc" "cmdstan-${VERSION}/bin/linux-stanc"
+    tar -czvf "cmdstan-${VERSION}-linux-${ARCH_NAME}.tar.gz" "cmdstan-${VERSION}"
+    rm "cmdstan-${VERSION}/bin/linux-stanc"
 done


### PR DESCRIPTION
I noticed I named the stanc3 binaries incorrectly in the tarballs so I went and fixed the script and then addressed a few minor things as well.