### PR TITLE
Update dockerfiles for 4.12

### DIFF
--- a/docker/stanc3/debian-windows/Dockerfile
+++ b/docker/stanc3/debian-windows/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -qq && apt-get install -y --no-install-recommends \
 
 #Copy our script and install ocaml + init
 COPY ./scripts/install_ocaml_windows.sh ./
-RUN printf "\n" | bash -x install_ocaml_windows.sh "--root=/usr/local/opam --comp 4.02.3 --disable-sandboxing -y"
+RUN printf "\n" | bash -x install_ocaml_windows.sh "--root=/usr/local/opam --disable-sandboxing -y"
 
 #Copy our script and install build dependencies
 COPY ./scripts/install_build_deps_windows.sh ./
@@ -24,7 +24,9 @@ RUN bash -x install_build_deps_windows.sh
 # COPY ./scripts/install_dev_deps.sh ./
 # RUN bash -x install_dev_deps.sh
 
-RUN opam install -y js_of_ocaml-compiler.3.4.0 js_of_ocaml-ppx.3.4.0 js_of_ocaml.3.4.0
+# Install Javascript dev environment
+COPY ./scripts/install_js_deps.sh ./
+RUN opam update; bash -x install_js_deps.sh
 
 #Specify our entrypoint
 ENTRYPOINT [ "opam", "config", "exec", "--" ]

--- a/docker/stanc3/debian/Dockerfile
+++ b/docker/stanc3/debian/Dockerfile
@@ -19,7 +19,7 @@ RUN opam update; bash -x install_build_deps.sh
 COPY ./scripts/install_dev_deps.sh ./
 RUN opam update; bash -x install_dev_deps.sh
 
-RUN opam update; opam install -y js_of_ocaml-compiler.3.4.0 js_of_ocaml-ppx.3.4.0 js_of_ocaml.3.4.0
+RUN opam update
 
 # Install Javascript dev environment
 COPY ./scripts/install_js_deps.sh ./

--- a/docker/stanc3/multiarch/Dockerfile
+++ b/docker/stanc3/multiarch/Dockerfile
@@ -32,30 +32,15 @@ RUN eval $(opam env)
 
 # Native-code compilation not available on MIPS, fall back to bytecode
 RUN if [ $(cat ./arch) = "mips64el" ]; then \
-    opam switch create 4.07.0+bytecode-only && opam switch 4.07.0+bytecode-only; \
+    opam switch create 4.12.0 --packages=ocaml-variants.4.12.0+options,ocaml-option-bytecode-only && opam switch 4.12.0; \
   else \
-    opam switch create 4.07.0 && opam switch 4.07.0; \
+    opam switch create 4.12.0 && opam switch 4.12.0; \
   fi
-  
+
 RUN eval $(opam env) && opam repo add internet https://opam.ocaml.org
 
-# Bytecode installation not available using older menhir version with opam,
-#   have to manually compile menhir with necessary flags
-RUN if [ $(cat ./arch) = "mips64el" ]; then \
-    curl https://gitlab.inria.fr/fpottier/menhir/-/archive/20181113/menhir-20181113.tar.gz --output menhir-20181113.tar.gz && \
-    tar -xf menhir-20181113.tar.gz && cd menhir-20181113/ && \
-    eval $(opam env) && opam install -y ocamlbuild ocamlfind && \
-    make -f Makefile PREFIX=/root/.opam/4.07.0+bytecode-only USE_OCAMLFIND=true docdir=/root/.opam/4.07.0+bytecode-only/doc/menhir libdir=/root/.opam/4.07.0+bytecode-only/lib/menhir mandir=/root/.opam/4.07.0+bytecode-only/man/man1 TARGET=byte all && \
-    make -f Makefile PREFIX=/root/.opam/4.07.0+bytecode-only USE_OCAMLFIND=true docdir=/root/.opam/4.07.0+bytecode-only/doc/menhir libdir=/root/.opam/4.07.0+bytecode-only/lib/menhir mandir=/root/.opam/4.07.0+bytecode-only/man/man1 TARGET=byte install; \
-    fi
 
-# If menhir already manually installed, then remove install command from bash script
-RUN if [ $(cat ./arch) = "mips64el" ]; then \
-    curl https://raw.githubusercontent.com/stan-dev/stanc3/master/scripts/install_build_deps.sh | \
-    sed 's/menhir.20181113//' | bash; \
-    else \
-    curl https://raw.githubusercontent.com/stan-dev/stanc3/master/scripts/install_build_deps.sh | bash; \
-    fi
+RUN curl https://raw.githubusercontent.com/stan-dev/stanc3/master/scripts/install_build_deps.sh | bash; \
 
 # Cleanup
 RUN rm ./arch && rm ./qarch

--- a/docker/stanc3/multiarch/Dockerfile
+++ b/docker/stanc3/multiarch/Dockerfile
@@ -40,7 +40,7 @@ RUN if [ $(cat ./arch) = "mips64el" ]; then \
 RUN eval $(opam env) && opam repo add internet https://opam.ocaml.org
 
 
-RUN curl https://raw.githubusercontent.com/stan-dev/stanc3/master/scripts/install_build_deps.sh | bash; \
+RUN curl https://raw.githubusercontent.com/stan-dev/stanc3/master/scripts/install_build_deps.sh | bash
 
 # Cleanup
 RUN rm ./arch && rm ./qarch

--- a/docker/stanc3/multiarch/Dockerfile
+++ b/docker/stanc3/multiarch/Dockerfile
@@ -1,6 +1,12 @@
 # Base image
 FROM debian:buster-slim
 
+ARG STANC3_BRANCH=master
+ENV STANC3_BRANCH_ENV=${STANC3_BRANCH}
+
+ARG STANC3_ORG=stan-dev
+ENV STANC3_ORG_ENV=${STANC3_ORG}
+
 # Update repositories and install OS deps
 RUN apt-get update
 RUN apt-get install opam curl bzip2 git tar curl ca-certificates openssl m4 bash -y
@@ -40,7 +46,7 @@ RUN if [ $(cat ./arch) = "mips64el" ]; then \
 RUN eval $(opam env) && opam repo add internet https://opam.ocaml.org
 
 
-RUN curl https://raw.githubusercontent.com/stan-dev/stanc3/master/scripts/install_build_deps.sh | bash
+RUN curl https://raw.githubusercontent.com/${STANC3_ORG_ENV}/stanc3/${STANC3_BRANCH_ENV}/scripts/install_build_deps.sh | bash
 
 # Cleanup
 RUN rm ./arch && rm ./qarch

--- a/docker/stanc3/static/Dockerfile
+++ b/docker/stanc3/static/Dockerfile
@@ -7,7 +7,6 @@ USER root
 
 #Add opam group
 
-RUN addgroup -g 1000 opam
 RUN addgroup -g 1004 jenkins-slave
 
 RUN delgroup opam nogroup

--- a/docker/stanc3/static/Dockerfile
+++ b/docker/stanc3/static/Dockerfile
@@ -1,6 +1,6 @@
 #Use Official Docker Images for OCAML/OPAM
 #https://github.com/ocaml/infrastructure/wiki/Containers
-FROM ocaml/opam2:alpine-3.9-ocaml-4.07
+FROM ocaml/opam:alpine-ocaml-4.12
 
 #Switch to root user so we can install apk packages
 USER root
@@ -32,8 +32,8 @@ USER opam
 
 #Init opam, create and switch to 4.07.0, update shell environment
 RUN opam init --disable-sandboxing -y
-RUN opam switch create 4.07.0
-RUN opam switch 4.07.0
+RUN opam switch create 4.12.0
+RUN opam switch 4.12.0
 RUN eval $(opam env)
 
 RUN opam repo add internet https://opam.ocaml.org


### PR DESCRIPTION
@serban-nicusor-toptal I believe this is what is necessary for the new docker build. The only problem is that I need all of the scripts to come from a non-master branch at the moment. The only hardcoded usage of master (I think) is in Dockerfile/multiarch, the rest just use the repo provided during the build in the Jenkinsfile.

Also, I believe this would overwrite the existing images we have? Which means nothing besides my pr would build. Please help me fix this up!