### PR TITLE
Added colab build script

### DIFF
--- a/release-scripts/build-conda-tgz.sh
+++ b/release-scripts/build-conda-tgz.sh
@@ -6,7 +6,7 @@
 # $1: cmdstan version in the form of 2.29.0 (major.minor.patch)
 
 # On a fresh colab instance simply run:
-# !curl https://raw.githubusercontent.com/stan-dev/ci-scripts/conda-tgz-script/release-scripts/build-conda-tgz.sh | bash -s -- 2.29.0
+# !curl https://raw.githubusercontent.com/stan-dev/ci-scripts/master/release-scripts/build-conda-tgz.sh | bash -s -- 2.29.0
 # You can follow all the progress in the console, should take around 10 minutes
 # At the end the console will print a URL where you can download the .tgz archive
 

--- a/release-scripts/build-conda-tgz.sh
+++ b/release-scripts/build-conda-tgz.sh
@@ -3,7 +3,7 @@
 # Script used to install cmdstan on a GColab Machine and create a .tgz archive with the installation
 
 # Arguments:
-# $1: cmdstan version ( will determine archive name )
+# $1: cmdstan version in the form of 2.29.0 (major.minor.patch)
 
 # On a fresh colab instance simply run:
 # !curl https://raw.githubusercontent.com/stan-dev/ci-scripts/conda-tgz-script/release-scripts/build-conda-tgz.sh | bash -s -- 2.29.0
@@ -21,7 +21,7 @@ pip install --upgrade cmdstanpy
 # Install cmdstan
 python <<HEREDOC
 from cmdstanpy import install_cmdstan
-install_cmdstan(cores=2, progress=True)
+install_cmdstan(cores=2, progress=True, version=$VERSION)
 HEREDOC
 
 # Create tgz archive

--- a/release-scripts/build-conda-tgz.sh
+++ b/release-scripts/build-conda-tgz.sh
@@ -19,10 +19,7 @@ echo "Creating v$VERSION conda .tgz archive !"
 pip install --upgrade cmdstanpy
 
 # Install cmdstan
-python <<HEREDOC
-from cmdstanpy import install_cmdstan
-install_cmdstan(cores=2, progress=True, version="$VERSION")
-HEREDOC
+python -c "from cmdstanpy import install_cmdstan; install_cmdstan(cores=2, progress=True, version=\"$VERSION\")"
 
 # Create tgz archive
 cd $INSTALLATION_HOME/.cmdstan; tar -cf - cmdstan-$VERSION | gzip > $INSTALLATION_HOME/cmdstan-$VERSION.tgz

--- a/release-scripts/build-conda-tgz.sh
+++ b/release-scripts/build-conda-tgz.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Script used to install cmdstan on a GColab Machine and create a .tgz archive with the installation
+# Usage example:
+# On a fresh colab instance simply run:
+# !curl https://gist.githubusercontent.com/serban-nicusor-toptal/412fb920f80f85b5e217e38ca86d5cbc/raw/7946e9f315e82537276d06843e1b9186c505bcfb/conda-cmdstan.sh | bash -s -- 2.29.0
+# You can follow all the progress in the console, should take around 10 minutes
+# At the end the console will print a URL where you can download the .tgz archive
+
+VERSION="$1"
+INSTALLATION_HOME="/root"
+
+echo "Creating v$VERSION conda .tgz archive !"
+
+# Install cmdstanpy
+pip install --upgrade cmdstanpy
+
+# Install cmdstan
+python <<HEREDOC
+from cmdstanpy import install_cmdstan
+install_cmdstan(cores=2, progress=True)
+HEREDOC
+
+# Create tgz archive
+cd $INSTALLATION_HOME/.cmdstan; tar -cf - cmdstan-$VERSION | gzip > $INSTALLATION_HOME/cmdstan-$VERSION.tgz
+tar -tzf $INSTALLATION_HOME/cmdstan-$VERSION.tgz | head
+
+# Use transfer.sh to upload our achive for easy retrieval
+curl --upload-file /root/cmdstan-$VERSION.tgz https://transfer.sh/cmdstan-$VERSION.tgz

--- a/release-scripts/build-conda-tgz.sh
+++ b/release-scripts/build-conda-tgz.sh
@@ -21,7 +21,7 @@ pip install --upgrade cmdstanpy
 # Install cmdstan
 python <<HEREDOC
 from cmdstanpy import install_cmdstan
-install_cmdstan(cores=2, progress=True, version=$VERSION)
+install_cmdstan(cores=2, progress=True, version="$VERSION")
 HEREDOC
 
 # Create tgz archive

--- a/release-scripts/build-conda-tgz.sh
+++ b/release-scripts/build-conda-tgz.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
 # Script used to install cmdstan on a GColab Machine and create a .tgz archive with the installation
-# Usage example:
+
+# Arguments:
+# $1: cmdstan version ( will determine archive name )
+
 # On a fresh colab instance simply run:
-# !curl https://gist.githubusercontent.com/serban-nicusor-toptal/412fb920f80f85b5e217e38ca86d5cbc/raw/7946e9f315e82537276d06843e1b9186c505bcfb/conda-cmdstan.sh | bash -s -- 2.29.0
+# !curl https://raw.githubusercontent.com/stan-dev/ci-scripts/conda-tgz-script/release-scripts/build-conda-tgz.sh | bash -s -- 2.29.0
 # You can follow all the progress in the console, should take around 10 minutes
 # At the end the console will print a URL where you can download the .tgz archive
 


### PR DESCRIPTION
Script used to install cmdstan on a GColab Machine and create a .tgz archive with the installation.

On a fresh colab instance simply run:
``` !curl https://raw.githubusercontent.com/stan-dev/ci-scripts/conda-tgz-script/release-scripts/build-conda-tgz.sh | bash -s -- 2.29.0```
You can follow all the progress in the console, should take around 10 minutes
At the end the console will print a URL where you can download the .tgz archive.

@WardBrian would you mind giving this a try when you have a minute? Thanks!

Closes #19 
