### PR TITLE
Bleeding edge monthly pipeline

### DIFF
--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -20,9 +20,9 @@ def setupMakeLocal() {
         echo CC="clang" >> make/local
         echo CXX="clang++" >> make/local
         echo CFLAGS="-stdlib=libc++" >> make/local
-        echo CPPFLAGS="-nostdinc++ -nodefaultlibs -I/usr/local/include/c++/v1 -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc" >> make/local
-        echo CXXFLAGS="-fsanitize=address -nostdinc++ -nostdlib++ -I/usr/local/include/c++/v1 -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++" >> make/local
-        echo LDFLAGS="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1" >> make/local
+        echo CPPFLAGS="-nostdinc++ -nodefaultlibs -I/usr/local/include/c++/v1" >> make/local
+        echo CXXFLAGS="-nostdinc++ -nostdlib++ -I/usr/local/include/c++/v1 -fsanitize=address" >> make/local
+        echo LDFLAGS="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc" >> make/local
     """
 }
 

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -26,7 +26,7 @@ def setupMakeLocal(String o = "", String cc = "" , String cxx = "" , String cFla
         echo CXX="clang++ ${cxx}" >> ${makeLocalPath}
         echo CFLAGS+="-stdlib=libc++ ${cFlags}" >> ${makeLocalPath}
         echo CPPFLAGS+="-nostdinc++ -nodefaultlibs -I/usr/local/include/c++/v1 ${cppFlags}" >> ${makeLocalPath}
-        echo CXXFLAGS+="-nostdinc++ -nostdlib++ -I/usr/local/include/c++/v1 -fsanitize=address ${cxxFlags}" >> ${makeLocalPath}
+        echo CXXFLAGS+="-nostdinc++ -nostdlib++ -I/usr/local/include/c++/v1 ${cxxFlags}" >> ${makeLocalPath}
         echo LDFLAGS+="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc ${ldFlags}" >> ${makeLocalPath}
     """
 }
@@ -59,7 +59,7 @@ def runPerformanceTests(String testsPath, String stancFlags = ""){
         cd performance-tests-cmdstan/cmdstan
         echo 'O=0' >> make/local
         make -j${env.PARALLEL} build; cd ..
-        python3 runPerformanceTests.py -j${env.PARALLEL} --runs=0 ${testsPath}
+        python3 runPerformanceTests.py -j${env.PARALLEL} --runs=2 ${testsPath}
     """
 }
 

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -428,7 +428,7 @@ pipeline {
                             python3 -m venv .venv
                             source .venv/bin/activate
                             python3 -m pip install statistics
-                            ./runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests
+                            python3 runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests
                         """
                         junit '*.xml'
                         archiveArtifacts '*.xml'
@@ -449,7 +449,7 @@ pipeline {
                         python3 -m venv .venv
                         source .venv/bin/activate
                         python3 -m pip install statistics
-                        ./runPerformanceTests.py --runs 2 --name=shotgun_perf --tests-file=shotgun_perf_all.tests
+                        python3 runPerformanceTests.py --runs 2 --name=shotgun_perf --tests-file=shotgun_perf_all.tests
                     """
                 }
             }

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -432,46 +432,6 @@ pipeline {
                     }
                     post { always { sh "rm -rf ${env.WORKSPACE}/compile-end-to-end-O=1/*" }}
                 }
-                stage('Math functions expressions test') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:bleeding-edge-compilers'
-                            label 'linux'
-                        }
-                    }
-                    steps {
-                        dir("${env.WORKSPACE}/compile-expressions"){
-                            unstash "Stanc3Setup"
-                            unstash 'ubuntu-exe'
-                            script {
-                                sh """
-                                    git clone --recursive https://github.com/stan-dev/math.git
-                                """
-                                utils.checkout_pr("math", "math", params.math_pr)
-                                sh """
-                                    cp bin/stanc math/test/expressions/stanc
-                                """
-
-                                dir("math") {
-                                    sh """
-                                        #!/usr/bin/env bash
-                                        echo O=0 >> make/local
-                                        echo "CXX=clang++ -Werror " >> make/local
-                                        # Fix for AttributeError: module 'collections' has no attribute 'Iterable'
-                                        # https://stackoverflow.com/questions/72371859/attributeerror-module-collections-has-no-attribute-iterable
-                                        # We might want to patch this in the main repository
-                                        sed -i 's/import collections/import collections\\ncollections.Iterable = collections.abc.Iterable/' test/code_generator.py
-                                    """
-                                    withEnv(['PATH+TBB=./lib/tbb']) {
-                                        try { sh "python3 runTests.py -j${env.PARALLEL} test/expressions" }
-                                        finally { junit 'test/**/*.xml' }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    post { always { sh "rm -rf ${env.WORKSPACE}/compile-expressions/*" }}
-                }
             }
         }
 

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -32,7 +32,7 @@ def setupMakeLocal(String o = "3", String cc = "clang" , String cxx = "clang++" 
             echo LDFLAGS+="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc ${ldFlags}" >> ${makeLocalPath}
         """
     }
-    sh "\$CXX --version"
+    sh "${cxx} --version"
 }
 
 def runPerformanceTests(String testsPath, String stancFlags = "", String compiler = "clang"){

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -89,6 +89,9 @@ pipeline {
                description: "Math PR to test against. Will check out this PR in the downstream Math repo.")
         string(defaultValue: 'master', name: 'stanc3_pr',
                description: "Stanc3 PR to test against. Will check out this PR in the downstream Math repo.")
+        booleanParam(defaultValue: true, description: 'Run Full Unit Tests', name: 'run_full_unit_tests')
+        booleanParam(defaultValue: true, description: 'Run CmdStan & Math tests', name: 'run_cmdstan_math_tests')
+        booleanParam(defaultValue: true, description: 'Run CmdStan Perf Tests', name: 'run_cmdstan_perf_tests')
     }
     environment {
         STAN_NUM_THREADS = 4
@@ -259,6 +262,10 @@ pipeline {
         }
 
         stage('Full Unit Tests') {
+            when {
+                beforeAgent true
+                expression { params.run_full_unit_tests }
+            }
             parallel {
                 stage('Rev/Fwd Unit Tests - CLANG') {
                     agent {
@@ -392,6 +399,10 @@ pipeline {
         }
 
         stage("CmdStan & Math tests") {
+            when {
+                beforeAgent true
+                expression { params.run_cmdstan_math_tests }
+            }
             parallel {
                 stage("Compile tests - good at O=1") {
                     agent {
@@ -613,6 +624,10 @@ pipeline {
         }
 
         stage('CmdStan Perf Tests') {
+            when {
+                beforeAgent true
+                expression { params.run_cmdstan_perf_tests }
+            }
             parallel {
                 stage('Numerical Accuracy and Performance Tests on Known-Good Models') {
                         // This will error out on MAC M1 architecture

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -20,9 +20,9 @@ def setupMakeLocal() {
         echo CC="clang" >> make/local
         echo CXX="clang++" >> make/local
         echo CFLAGS="-stdlib=libc++" >> make/local
-        echo CPPFLAGS="-nostdinc++ -nodefaultlibs -I/usr/local/include/c++/v1" >> make/local
-        echo CXXFLAGS="-nostdinc++ -nostdlib++ -I/usr/local/include/c++/v1 -fsanitize=address" >> make/local
-        echo LDFLAGS="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1 -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc" >> make/local
+        echo CPPFLAGS="-nostdinc++ -nodefaultlibs -I/usr/local/include/c++/v1 -L/usr/local/lib -Wl,-rpath,/usr/local/lib" >> make/local
+        echo CXXFLAGS="-nostdinc++ -nostdlib++ -I/usr/local/include/c++/v1 -fsanitize=address -L/usr/local/lib -Wl,-rpath,/usr/local/lib" >> make/local
+        echo LDFLAGS="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1 -lc++ -lc++abi -lm -lc -lgcc_s -lgcc" >> make/local
     """
 }
 

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -409,6 +409,7 @@ pipeline {
         stage('CmdStan Perf Tests') {
             parallel {
                 stage("Numerical Accuracy and Performance Tests on Known-Good Models") {
+                    // This will error out on MAC M1 architecture
                     agent { label 'osx && intel' }
                     steps {
                         unstash "PerfSetup"

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -32,11 +32,6 @@ def setupMakeLocal(String o = "3", String cc = "clang" , String cxx = "clang++" 
             echo LDFLAGS+="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc ${ldFlags}" >> ${makeLocalPath}
         """
     }
-    else {
-        sh """
-            echo CFLAGS+="-stdlib=libstdc++" >> ${makeLocalPath}
-        """
-    }
     sh "${cxx} --version"
 }
 
@@ -409,60 +404,6 @@ pipeline {
                 expression { params.run_cmdstan_math_tests }
             }
             parallel {
-                stage("Compile tests - good at O=1 - CLANG") {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:bleeding-edge-compilers'
-                            label 'linux'
-                            args '--pull always'
-                        }
-                    }
-                    steps {
-                        dir("${env.WORKSPACE}/compile-good-O1"){
-                            unstash "Stanc3Setup"
-                            script {
-                                runPerformanceTests("../test/integration/good", "--O1", "clang")
-                            }
-
-                            xunit([GoogleTest(
-                                deleteOutputFiles: false,
-                                failIfNotNew: true,
-                                pattern: 'performance-tests-cmdstan/performance.xml',
-                                skipNoTestFiles: false,
-                                stopProcessingIfError: false)
-                            ])
-                        }
-                    }
-                    post { always { sh "rm -rf ${env.WORKSPACE}/compile-good-O1/*" }}
-                }
-
-                stage("Compile tests - example-models at O=1 - CLANG") {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:bleeding-edge-compilers'
-                            label 'linux'
-                            args '--pull always'
-                        }
-                    }
-                    steps {
-                        dir("${env.WORKSPACE}/compile-example-O1"){
-                            script {
-                                unstash "Stanc3Setup"
-                                runPerformanceTests("example-models", "--O1", "clang")
-                            }
-
-                            xunit([GoogleTest(
-                                deleteOutputFiles: false,
-                                failIfNotNew: true,
-                                pattern: 'performance-tests-cmdstan/performance.xml',
-                                skipNoTestFiles: false,
-                                stopProcessingIfError: false)
-                            ])
-                        }
-                    }
-                    post { always { sh "rm -rf ${env.WORKSPACE}/compile-example-O1/*" }}
-                }
-
                 stage("Model end-to-end - CLANG") {
                     agent {
                         docker {
@@ -482,7 +423,7 @@ pipeline {
                                 utils.checkout_pr("cmdstan", "performance-tests-cmdstan/cmdstan", params.cmdstan_pr)
                                 utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
                                 utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
-                                setupMakeLocal("3","clang", "clang++ -ltbb","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
+                                setupMakeLocal("3","clang", "clang++","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
                                 sh """
                                     cd performance-tests-cmdstan
                                     git show HEAD --stat
@@ -517,60 +458,6 @@ pipeline {
                     }
                     post { always { sh "rm -rf ${env.WORKSPACE}/compile-end-to-end-O=1/*" }}
                 }
-                stage("Compile tests - good at O=1 - GCC") {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:bleeding-edge-compilers'
-                            label 'linux'
-                            args '--pull always'
-                        }
-                    }
-                    steps {
-                        dir("${env.WORKSPACE}/compile-good-O1"){
-                            unstash "Stanc3Setup"
-                            script {
-                                runPerformanceTests("../test/integration/good", "--O1", "gcc")
-                            }
-
-                            xunit([GoogleTest(
-                                deleteOutputFiles: false,
-                                failIfNotNew: true,
-                                pattern: 'performance-tests-cmdstan/performance.xml',
-                                skipNoTestFiles: false,
-                                stopProcessingIfError: false)
-                            ])
-                        }
-                    }
-                    post { always { sh "rm -rf ${env.WORKSPACE}/compile-good-O1/*" }}
-                }
-
-                stage("Compile tests - example-models at O=1 - GCC") {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:bleeding-edge-compilers'
-                            label 'linux'
-                            args '--pull always'
-                        }
-                    }
-                    steps {
-                        dir("${env.WORKSPACE}/compile-example-O1"){
-                            script {
-                                unstash "Stanc3Setup"
-                                runPerformanceTests("example-models", "--O1", "gcc")
-                            }
-
-                            xunit([GoogleTest(
-                                deleteOutputFiles: false,
-                                failIfNotNew: true,
-                                pattern: 'performance-tests-cmdstan/performance.xml',
-                                skipNoTestFiles: false,
-                                stopProcessingIfError: false)
-                            ])
-                        }
-                    }
-                    post { always { sh "rm -rf ${env.WORKSPACE}/compile-example-O1/*" }}
-                }
-
                 stage("Model end-to-end - GCC") {
                     agent {
                         docker {
@@ -590,7 +477,7 @@ pipeline {
                                 utils.checkout_pr("cmdstan", "performance-tests-cmdstan/cmdstan", params.cmdstan_pr)
                                 utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
                                 utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
-                                setupMakeLocal("3","gcc","g++ -ltbb","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
+                                setupMakeLocal("3","gcc","g++","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
                                 sh """
                                     cd performance-tests-cmdstan
                                     git show HEAD --stat

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -303,35 +303,6 @@ pipeline {
             }
         }
 
-        stage('CmdStan Perf Tests') {
-            parallel {
-                stage("Numerical Accuracy and Performance Tests on Known-Good Models") {
-                    agent { label 'osx && intel' }
-                    steps {
-                        unstash "PerfSetup"
-                        setupMakeLocal("","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
-                        sh "python3 runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests"
-                        junit '*.xml'
-                        archiveArtifacts '*.xml'
-                }
-            }
-            stage('Shotgun Performance Regression Tests') {
-                agent {
-                    docker {
-                        image 'stanorg/ci:bleeding-edge-compilers'
-                        label 'linux'
-                        args '--pull always'
-                    }
-                }
-                steps {
-                    unstash "PerfSetup"
-                    setupMakeLocal("","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
-                    sh "python3 runPerformanceTests.py --runs 2 --name=shotgun_perf --tests-file=shotgun_perf_all.tests "
-                }
-            }
-            }
-        }
-
         stage("CmdStan & Math tests") {
             parallel {
                 stage("Compile tests - good at O=1") {
@@ -432,6 +403,35 @@ pipeline {
                     }
                     post { always { sh "rm -rf ${env.WORKSPACE}/compile-end-to-end-O=1/*" }}
                 }
+            }
+        }
+
+        stage('CmdStan Perf Tests') {
+            parallel {
+                stage("Numerical Accuracy and Performance Tests on Known-Good Models") {
+                    agent { label 'osx && intel' }
+                    steps {
+                        unstash "PerfSetup"
+                        setupMakeLocal("","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
+                        sh "python3 runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests"
+                        junit '*.xml'
+                        archiveArtifacts '*.xml'
+                }
+            }
+            stage('Shotgun Performance Regression Tests') {
+                agent {
+                    docker {
+                        image 'stanorg/ci:bleeding-edge-compilers'
+                        label 'linux'
+                        args '--pull always'
+                    }
+                }
+                steps {
+                    unstash "PerfSetup"
+                    setupMakeLocal("","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
+                    sh "python3 runPerformanceTests.py --runs 2 --name=shotgun_perf --tests-file=shotgun_perf_all.tests "
+                }
+            }
             }
         }
 

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -482,7 +482,7 @@ pipeline {
                                 utils.checkout_pr("cmdstan", "performance-tests-cmdstan/cmdstan", params.cmdstan_pr)
                                 utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
                                 utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
-                                setupMakeLocal("3","clang", "clang++","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
+                                setupMakeLocal("3","clang", "clang++ -ltbb","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
                                 sh """
                                     cd performance-tests-cmdstan
                                     git show HEAD --stat
@@ -590,7 +590,7 @@ pipeline {
                                 utils.checkout_pr("cmdstan", "performance-tests-cmdstan/cmdstan", params.cmdstan_pr)
                                 utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
                                 utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
-                                setupMakeLocal("3","gcc","g++","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
+                                setupMakeLocal("3","gcc","g++ -ltbb","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
                                 sh """
                                     cd performance-tests-cmdstan
                                     git show HEAD --stat

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -18,10 +18,9 @@ def runTests(String testPath, boolean jumbo = false) {
     finally { junit 'test/**/*.xml' }
 }
 
-def setupMakeLocal(String o = "", String cc = "" , String cxx = "" , String cFlags = "", String cppFlags = "", String cxxFlags = "", String ldFlags = "", String makeLocalPath = "make/local") {
-    // When ready, change O=3
-    //         echo O="${o}" >> ${makeLocalPath}
+def setupMakeLocal(String o = "3", String cc = "" , String cxx = "" , String cFlags = "", String cppFlags = "", String cxxFlags = "", String ldFlags = "", String makeLocalPath = "make/local") {
     sh """
+        echo O="${o}" >> ${makeLocalPath}
         echo CC="clang ${cc}" >> ${makeLocalPath}
         echo CXX="clang++ ${cxx}" >> ${makeLocalPath}
         echo CFLAGS+="-stdlib=libc++ ${cFlags}" >> ${makeLocalPath}
@@ -122,32 +121,32 @@ pipeline {
             }
         }
 
-        // stage('Prepare math') {
-        //     agent {
-        //         docker {
-        //             image 'alpine/git'
-        //             label 'linux'
-        //             args "--entrypoint=\'\'"
-        //         }
-        //     }
-        //     steps {
-        //         script {
-        //             sh """
-        //                 rm -rf math
-        //                 git clone https://github.com/stan-dev/math.git
-        //                 cd math
-        //                 git checkout ${params.math_pr}
-        //                 git clean -xffd
-        //             """
-        //             stash 'MathSetup'
-        //         }
-        //     }
-        //     post {
-        //         always {
-        //             deleteDir()
-        //         }
-        //     }
-        // }
+        stage('Prepare math') {
+            agent {
+                docker {
+                    image 'alpine/git'
+                    label 'linux'
+                    args "--entrypoint=\'\'"
+                }
+            }
+            steps {
+                script {
+                    sh """
+                        rm -rf math
+                        git clone https://github.com/stan-dev/math.git
+                        cd math
+                        git checkout ${params.math_pr}
+                        git clean -xffd
+                    """
+                    stash 'MathSetup'
+                }
+            }
+            post {
+                always {
+                    deleteDir()
+                }
+            }
+        }
 
         stage('Prepare Performance-Tests-Cmdstan') {
             agent {
@@ -182,239 +181,239 @@ pipeline {
             }
         }
 
-        // stage('Prepare stanc3') {
-        //     agent {
-        //         docker {
-        //             image 'alpine/git'
-        //             label 'linux'
-        //             args "--entrypoint=\'\'"
-        //         }
-        //     }
-        //     steps {
-        //         script {
-        //             sh """
-        //                 rm -rf stanc3
-        //                 git clone https://github.com/stan-dev/stanc3.git
-        //                 cd stanc3
-        //                 git submodule update --init --recursive
-        //                 git checkout ${params.stanc3_pr}
-        //                 git clean -xffd
-        //             """
+        stage('Prepare stanc3') {
+            agent {
+                docker {
+                    image 'alpine/git'
+                    label 'linux'
+                    args "--entrypoint=\'\'"
+                }
+            }
+            steps {
+                script {
+                    sh """
+                        rm -rf stanc3
+                        git clone https://github.com/stan-dev/stanc3.git
+                        cd stanc3
+                        git submodule update --init --recursive
+                        git checkout ${params.stanc3_pr}
+                        git clean -xffd
+                    """
 
-        //             stash 'Stanc3Setup'
-        //         }
-        //     }
-        //     post {
-        //         always {
-        //             deleteDir()
-        //         }
-        //     }
-        // }
+                    stash 'Stanc3Setup'
+                }
+            }
+            post {
+                always {
+                    deleteDir()
+                }
+            }
+        }
     
-        // stage("Build Stanc3") {
-        //     agent {
-        //         docker {
-        //             image 'stanorg/stanc3:debianfi'
-        //             //Forces image to ignore entrypoint
-        //             args "--entrypoint=\'\'"
-        //             label 'linux'
-        //         }
-        //     }
-        //     steps {
-        //         unstash "Stanc3Setup"
-        //         sh"""
-        //             eval \$(opam env)
-        //             dune build @install
-        //         """
+        stage("Build Stanc3") {
+            agent {
+                docker {
+                    image 'stanorg/stanc3:debianfi'
+                    //Forces image to ignore entrypoint
+                    args "--entrypoint=\'\'"
+                    label 'linux'
+                }
+            }
+            steps {
+                unstash "Stanc3Setup"
+                sh"""
+                    eval \$(opam env)
+                    dune build @install
+                """
 
-        //         sh "mkdir -p bin && mv _build/default/stanc3/src/stanc/stanc.exe bin/stanc"
-        //         stash name:'ubuntu-exe', includes:'bin/stanc, notes/working-models.txt'
-        //     }
-        //     post { always { sh "rm -rf ./*" }}
-        // }
+                sh "mkdir -p bin && mv _build/default/stanc3/src/stanc/stanc.exe bin/stanc"
+                stash name:'ubuntu-exe', includes:'bin/stanc, notes/working-models.txt'
+            }
+            post { always { sh "rm -rf ./*" }}
+        }
 
-        // stage('Full Unit Tests') {
-        //     failFast true
-        //     parallel {
-        //         stage('Rev/Fwd Unit Tests') {
-        //             agent {
-        //                 docker {
-        //                     image 'stanorg/ci:bleeding-edge-compilers'
-        //                     label 'linux'
-        //                     args '--pull always --cap-add SYS_PTRACE'
-        //                 }
-        //             }
-        //             steps {
-        //                 unstash 'MathSetup'
-        //                 dir('math') {
-        //                     script {
-        //                         setupMakeLocal()
-        //                         runTests("test/unit/math/rev")
-        //                         runTests("test/unit/math/fwd")
-        //                     }
-        //                 }
+        stage('Full Unit Tests') {
+            failFast true
+            parallel {
+                stage('Rev/Fwd Unit Tests') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:bleeding-edge-compilers'
+                            label 'linux'
+                            args '--pull always --cap-add SYS_PTRACE'
+                        }
+                    }
+                    steps {
+                        unstash 'MathSetup'
+                        dir('math') {
+                            script {
+                                setupMakeLocal()
+                                runTests("test/unit/math/rev")
+                                runTests("test/unit/math/fwd")
+                            }
+                        }
 
-        //             }
-        //             post { always { retry(3) { deleteDir() } } }
-        //         }
-        //         stage('Mix Unit Tests') {
-        //             agent {
-        //                 docker {
-        //                     image 'stanorg/ci:bleeding-edge-compilers'
-        //                     label 'linux'
-        //                     args '--pull always --cap-add SYS_PTRACE'
-        //                 }
-        //             }
-        //             steps {
-        //                 unstash 'MathSetup'
-        //                 dir('math') {
-        //                     script {
-        //                         setupMakeLocal()
-        //                         runTests("test/unit/math/mix", true)
-        //                     }
-        //                 }
+                    }
+                    post { always { retry(3) { deleteDir() } } }
+                }
+                stage('Mix Unit Tests') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:bleeding-edge-compilers'
+                            label 'linux'
+                            args '--pull always --cap-add SYS_PTRACE'
+                        }
+                    }
+                    steps {
+                        unstash 'MathSetup'
+                        dir('math') {
+                            script {
+                                setupMakeLocal()
+                                runTests("test/unit/math/mix", true)
+                            }
+                        }
 
-        //             }
-        //             post { always { retry(3) { deleteDir() } } }
-        //         }
-        //         stage('Prim Unit Tests') {
-        //             agent {
-        //                 docker {
-        //                     image 'stanorg/ci:bleeding-edge-compilers'
-        //                     label 'linux'
-        //                     args '--pull always --cap-add SYS_PTRACE'
-        //                 }
-        //             }
-        //             steps {
-        //                 unstash 'MathSetup'
-        //                 dir('math') {
-        //                     script {
-        //                         setupMakeLocal()
-        //                         runTests("test/unit/*_test.cpp", false)
-        //                         runTests("test/unit/math/*_test.cpp", false)
-        //                         runTests("test/unit/math/prim", true)
-        //                         runTests("test/unit/math/memory", false)
-        //                     }
-        //                 }
+                    }
+                    post { always { retry(3) { deleteDir() } } }
+                }
+                stage('Prim Unit Tests') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:bleeding-edge-compilers'
+                            label 'linux'
+                            args '--pull always --cap-add SYS_PTRACE'
+                        }
+                    }
+                    steps {
+                        unstash 'MathSetup'
+                        dir('math') {
+                            script {
+                                setupMakeLocal()
+                                runTests("test/unit/*_test.cpp", false)
+                                runTests("test/unit/math/*_test.cpp", false)
+                                runTests("test/unit/math/prim", true)
+                                runTests("test/unit/math/memory", false)
+                            }
+                        }
 
-        //             }
-        //             post { always { retry(3) { deleteDir() } } }
-        //         }
-        //     }
-        // }
+                    }
+                    post { always { retry(3) { deleteDir() } } }
+                }
+            }
+        }
 
-        // stage("CmdStan & Math tests") {
-        //     parallel {
-        //         stage("Compile tests - good at O=1") {
-        //             agent {
-        //                 docker {
-        //                     image 'stanorg/ci:bleeding-edge-compilers'
-        //                     label 'linux'
-        //                     args '--pull always'
-        //                 }
-        //             }
-        //             steps {
-        //                 dir("${env.WORKSPACE}/compile-good-O1"){
-        //                     unstash "Stanc3Setup"
-        //                     script {
-        //                         runPerformanceTests("../test/integration/good", "--O1")
-        //                     }
+        stage("CmdStan & Math tests") {
+            parallel {
+                stage("Compile tests - good at O=1") {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:bleeding-edge-compilers'
+                            label 'linux'
+                            args '--pull always'
+                        }
+                    }
+                    steps {
+                        dir("${env.WORKSPACE}/compile-good-O1"){
+                            unstash "Stanc3Setup"
+                            script {
+                                runPerformanceTests("../test/integration/good", "--O1")
+                            }
 
-        //                     xunit([GoogleTest(
-        //                         deleteOutputFiles: false,
-        //                         failIfNotNew: true,
-        //                         pattern: 'performance-tests-cmdstan/performance.xml',
-        //                         skipNoTestFiles: false,
-        //                         stopProcessingIfError: false)
-        //                     ])
-        //                 }
-        //             }
-        //             post { always { sh "rm -rf ${env.WORKSPACE}/compile-good-O1/*" }}
-        //         }
+                            xunit([GoogleTest(
+                                deleteOutputFiles: false,
+                                failIfNotNew: true,
+                                pattern: 'performance-tests-cmdstan/performance.xml',
+                                skipNoTestFiles: false,
+                                stopProcessingIfError: false)
+                            ])
+                        }
+                    }
+                    post { always { sh "rm -rf ${env.WORKSPACE}/compile-good-O1/*" }}
+                }
 
-        //         stage("Compile tests - example-models at O=1") {
-        //             agent {
-        //                 docker {
-        //                     image 'stanorg/ci:bleeding-edge-compilers'
-        //                     label 'linux'
-        //                     args '--pull always'
-        //                 }
-        //             }
-        //             steps {
-        //                 dir("${env.WORKSPACE}/compile-example-O1"){
-        //                     script {
-        //                         unstash "Stanc3Setup"
-        //                         runPerformanceTests("example-models", "--O1")
-        //                     }
+                stage("Compile tests - example-models at O=1") {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:bleeding-edge-compilers'
+                            label 'linux'
+                            args '--pull always'
+                        }
+                    }
+                    steps {
+                        dir("${env.WORKSPACE}/compile-example-O1"){
+                            script {
+                                unstash "Stanc3Setup"
+                                runPerformanceTests("example-models", "--O1")
+                            }
 
-        //                     xunit([GoogleTest(
-        //                         deleteOutputFiles: false,
-        //                         failIfNotNew: true,
-        //                         pattern: 'performance-tests-cmdstan/performance.xml',
-        //                         skipNoTestFiles: false,
-        //                         stopProcessingIfError: false)
-        //                     ])
-        //                 }
-        //             }
-        //             post { always { sh "rm -rf ${env.WORKSPACE}/compile-example-O1/*" }}
-        //         }
+                            xunit([GoogleTest(
+                                deleteOutputFiles: false,
+                                failIfNotNew: true,
+                                pattern: 'performance-tests-cmdstan/performance.xml',
+                                skipNoTestFiles: false,
+                                stopProcessingIfError: false)
+                            ])
+                        }
+                    }
+                    post { always { sh "rm -rf ${env.WORKSPACE}/compile-example-O1/*" }}
+                }
 
-        //         stage("Model end-to-end tests at O=1") {
-        //             agent {
-        //                 docker {
-        //                     image 'stanorg/ci:bleeding-edge-compilers'
-        //                     label 'linux'
-        //                     args '--pull always'
-        //                 }
-        //             }
-        //             steps {
-        //                 dir("${env.WORKSPACE}/compile-end-to-end-O=1"){
-        //                     script {
-        //                         unstash "Stanc3Setup"
-        //                         unstash 'ubuntu-exe'
-        //                         sh """
-        //                             git clone --recursive --depth 50 https://github.com/stan-dev/performance-tests-cmdstan
-        //                         """
-        //                         utils.checkout_pr("cmdstan", "performance-tests-cmdstan/cmdstan", params.cmdstan_pr)
-        //                         utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
-        //                         utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
-        //                         setupMakeLocal("0","","","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
-        //                         sh """
-        //                             cd performance-tests-cmdstan
-        //                             git show HEAD --stat
-        //                             echo "example-models/regression_tests/mother.stan" > all.tests
-        //                             cat known_good_perf_all.tests >> all.tests
-        //                             echo "" >> all.tests
-        //                             cat shotgun_perf_all.tests >> all.tests
-        //                             cat all.tests
-        //                             echo "PRECOMPILED_HEADERS=false" >> cmdstan/make/local
-        //                             pwd
-        //                             cd cmdstan; make clean-all; git show HEAD --stat; make -j4 build
-        //                             pwd
-        //                             rm bin/stanc
-        //                             cp ../../bin/stanc bin/stanc
-        //                             make print-compiler-flags
-        //                             make -j4 examples/bernoulli/bernoulli; ./bin/stanc --version; cd ..
-        //                             echo "STANCFLAGS += --O1" >> cmdstan/make/local
-        //                             ./runPerformanceTests.py --overwrite-golds --tests-file all.tests --num-samples=20
-        //                         """
-        //                     }
+                stage("Model end-to-end") {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:bleeding-edge-compilers'
+                            label 'linux'
+                            args '--pull always'
+                        }
+                    }
+                    steps {
+                        dir("${env.WORKSPACE}/compile-end-to-end-O=1"){
+                            script {
+                                unstash "Stanc3Setup"
+                                unstash 'ubuntu-exe'
+                                sh """
+                                    git clone --recursive --depth 50 https://github.com/stan-dev/performance-tests-cmdstan
+                                """
+                                utils.checkout_pr("cmdstan", "performance-tests-cmdstan/cmdstan", params.cmdstan_pr)
+                                utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
+                                utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
+                                setupMakeLocal("3","","","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
+                                sh """
+                                    cd performance-tests-cmdstan
+                                    git show HEAD --stat
+                                    echo "example-models/regression_tests/mother.stan" > all.tests
+                                    cat known_good_perf_all.tests >> all.tests
+                                    echo "" >> all.tests
+                                    cat shotgun_perf_all.tests >> all.tests
+                                    cat all.tests
+                                    echo "PRECOMPILED_HEADERS=false" >> cmdstan/make/local
+                                    pwd
+                                    cd cmdstan; make clean-all; git show HEAD --stat; make -j4 build
+                                    pwd
+                                    rm bin/stanc
+                                    cp ../../bin/stanc bin/stanc
+                                    make print-compiler-flags
+                                    make -j4 examples/bernoulli/bernoulli; ./bin/stanc --version; cd ..
+                                    echo "STANCFLAGS += --O1" >> cmdstan/make/local
+                                    ./runPerformanceTests.py --overwrite-golds --tests-file all.tests --num-samples=20
+                                """
+                            }
 
-        //                     xunit([GoogleTest(
-        //                         deleteOutputFiles: false,
-        //                         failIfNotNew: true,
-        //                         pattern: 'performance-tests-cmdstan/performance.xml',
-        //                         skipNoTestFiles: false,
-        //                         stopProcessingIfError: false)
-        //                     ])
+                            xunit([GoogleTest(
+                                deleteOutputFiles: false,
+                                failIfNotNew: true,
+                                pattern: 'performance-tests-cmdstan/performance.xml',
+                                skipNoTestFiles: false,
+                                stopProcessingIfError: false)
+                            ])
 
-        //                     archiveArtifacts 'performance-tests-cmdstan/performance.xml'
-        //                 }
-        //             }
-        //             post { always { sh "rm -rf ${env.WORKSPACE}/compile-end-to-end-O=1/*" }}
-        //         }
-        //     }
-        // }
+                            archiveArtifacts 'performance-tests-cmdstan/performance.xml'
+                        }
+                    }
+                    post { always { sh "rm -rf ${env.WORKSPACE}/compile-end-to-end-O=1/*" }}
+                }
+            }
+        }
 
         stage('CmdStan Perf Tests') {
             parallel {

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -386,8 +386,7 @@ pipeline {
                                     cat all.tests
                                     echo "PRECOMPILED_HEADERS=false" >> cmdstan/make/local
                                     cd cmdstan; make clean-all; git show HEAD --stat; cd ..
-                                    chmod +x runPerformanceTests.py
-                                    chmod +x compare-optimizer.sh
+                                    alias python="python3 "
                                     CXX="clang++" ./compare-optimizer.sh "--tests-file all.tests --num-samples=10" "--O1" "\$(readlink -f ../bin/stanc)"
                                 """
                             }

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -91,7 +91,6 @@ pipeline {
                description: "Stanc3 PR to test against. Will check out this PR in the downstream Math repo.")
         booleanParam(defaultValue: true, description: 'Run Full Unit Tests', name: 'run_full_unit_tests')
         booleanParam(defaultValue: true, description: 'Run CmdStan & Math tests', name: 'run_cmdstan_math_tests')
-        booleanParam(defaultValue: true, description: 'Run CmdStan Perf Tests', name: 'run_cmdstan_perf_tests')
     }
     environment {
         STAN_NUM_THREADS = 4
@@ -511,85 +510,6 @@ pipeline {
                         }
                     }
                     post { always { sh "rm -rf ${env.WORKSPACE}/compile-end-to-end-O=1/*" }}
-                }
-            }
-        }
-
-        stage('CmdStan Perf Tests') {
-            when {
-                beforeAgent true
-                expression { params.run_cmdstan_perf_tests }
-            }
-            parallel {
-                stage('Numerical Accuracy and Performance Tests on Known-Good Models - CLANG') {
-                        // This will error out on MAC M1 architecture
-                        agent { label 'osx && intel' }
-                        steps {
-                            unstash "PerfSetup"
-                            setupMakeLocal("0","clang","clang++","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
-                            sh """
-                                python3 -m venv .venv
-                                source .venv/bin/activate
-                                python3 -m pip install statistics
-                                python3 runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests
-                            """
-                            junit '*.xml'
-                            archiveArtifacts '*.xml'
-                    }
-                }
-                stage('Shotgun Performance Regression Tests - CLANG') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:bleeding-edge-compilers'
-                            label 'linux'
-                            args '--pull always'
-                        }
-                    }
-                    steps {
-                        unstash "PerfSetup"
-                        setupMakeLocal("0","clang","clang++","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
-                        sh """
-                            python3 -m venv .venv
-                            source .venv/bin/activate
-                            python3 -m pip install statistics
-                            python3 runPerformanceTests.py --runs 2 --name=shotgun_perf --tests-file=shotgun_perf_all.tests
-                        """
-                    }
-                }
-                stage('Numerical Accuracy and Performance Tests on Known-Good Models - GCC') {
-                        // This will error out on MAC M1 architecture
-                        agent { label 'osx && intel' }
-                        steps {
-                            unstash "PerfSetup"
-                            setupMakeLocal("0","gcc","g++","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
-                            sh """
-                                python3 -m venv .venv
-                                source .venv/bin/activate
-                                python3 -m pip install statistics
-                                python3 runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests
-                            """
-                            junit '*.xml'
-                            archiveArtifacts '*.xml'
-                    }
-                }
-                stage('Shotgun Performance Regression Tests - GCC') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:bleeding-edge-compilers'
-                            label 'linux'
-                            args '--pull always'
-                        }
-                    }
-                    steps {
-                        unstash "PerfSetup"
-                        setupMakeLocal("0","gcc","g++","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
-                        sh """
-                            python3 -m venv .venv
-                            source .venv/bin/activate
-                            python3 -m pip install statistics
-                            python3 runPerformanceTests.py --runs 2 --name=shotgun_perf --tests-file=shotgun_perf_all.tests
-                        """
-                    }
                 }
             }
         }

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -18,19 +18,23 @@ def runTests(String testPath, boolean jumbo = false) {
     finally { junit 'test/**/*.xml' }
 }
 
-def setupMakeLocal(String o = "3", String cc = "" , String cxx = "" , String cFlags = "", String cppFlags = "", String cxxFlags = "", String ldFlags = "", String makeLocalPath = "make/local") {
+def setupMakeLocal(String o = "3", String cc = "clang" , String cxx = "clang++" , String cFlags = "", String cppFlags = "", String cxxFlags = "", String ldFlags = "", String makeLocalPath = "make/local") {
     sh """
         echo O="${o}" >> ${makeLocalPath}
-        echo CC="clang ${cc}" >> ${makeLocalPath}
-        echo CXX="clang++ ${cxx}" >> ${makeLocalPath}
-        echo CFLAGS+="-stdlib=libc++ ${cFlags}" >> ${makeLocalPath}
-        echo CPPFLAGS+="-nostdinc++ -nodefaultlibs -I/usr/local/include/c++/v1 ${cppFlags}" >> ${makeLocalPath}
-        echo CXXFLAGS+="-nostdinc++ -nostdlib++ -I/usr/local/include/c++/v1 ${cxxFlags}" >> ${makeLocalPath}
-        echo LDFLAGS+="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc ${ldFlags}" >> ${makeLocalPath}
+        echo CC="${cc}" >> ${makeLocalPath}
+        echo CXX="${cxx}" >> ${makeLocalPath}
     """
+    if (cc = "clang") {
+        sh """
+            echo CFLAGS+="-stdlib=libc++ ${cFlags}" >> ${makeLocalPath}
+            echo CPPFLAGS+="-nostdinc++ -nodefaultlibs -I/usr/local/include/c++/v1 ${cppFlags}" >> ${makeLocalPath}
+            echo CXXFLAGS+="-nostdinc++ -nostdlib++ -I/usr/local/include/c++/v1 ${cxxFlags}" >> ${makeLocalPath}
+            echo LDFLAGS+="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc ${ldFlags}" >> ${makeLocalPath}
+        """
+    }
 }
 
-def runPerformanceTests(String testsPath, String stancFlags = ""){
+def runPerformanceTests(String testsPath, String stancFlags = "", String compiler = "clang"){
     unstash 'ubuntu-exe'
 
     sh """
@@ -41,7 +45,12 @@ def runPerformanceTests(String testsPath, String stancFlags = ""){
     utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
     utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
 
-    setupMakeLocal("0","","","","","", "-ltbb", "performance-tests-cmdstan/cmdstan/make/local")
+    if (compiler == "gcc"){
+        setupMakeLocal("0","gcc","gcc++","","","", "-ltbb", "performance-tests-cmdstan/cmdstan/make/local")
+    }
+    else if (compiler == "clang"){
+        setupMakeLocal("0","clang","clang++","","","", "-ltbb", "performance-tests-cmdstan/cmdstan/make/local")
+    }
 
     sh """
         cd performance-tests-cmdstan
@@ -250,9 +259,8 @@ pipeline {
         }
 
         stage('Full Unit Tests') {
-            failFast true
             parallel {
-                stage('Rev/Fwd Unit Tests') {
+                stage('Rev/Fwd Unit Tests - CLANG') {
                     agent {
                         docker {
                             image 'stanorg/ci:bleeding-edge-compilers'
@@ -264,7 +272,7 @@ pipeline {
                         unstash 'MathSetup'
                         dir('math') {
                             script {
-                                setupMakeLocal()
+                                setupMakeLocal("3", "clang", "clang++")
                                 runTests("test/unit/math/rev")
                                 runTests("test/unit/math/fwd")
                             }
@@ -273,7 +281,7 @@ pipeline {
                     }
                     post { always { retry(3) { deleteDir() } } }
                 }
-                stage('Mix Unit Tests') {
+                stage('Mix Unit Tests - CLANG') {
                     agent {
                         docker {
                             image 'stanorg/ci:bleeding-edge-compilers'
@@ -285,7 +293,7 @@ pipeline {
                         unstash 'MathSetup'
                         dir('math') {
                             script {
-                                setupMakeLocal()
+                                setupMakeLocal("3", "clang", "clang++")
                                 runTests("test/unit/math/mix", true)
                             }
                         }
@@ -293,7 +301,7 @@ pipeline {
                     }
                     post { always { retry(3) { deleteDir() } } }
                 }
-                stage('Prim Unit Tests') {
+                stage('Prim Unit Tests - CLANG') {
                     agent {
                         docker {
                             image 'stanorg/ci:bleeding-edge-compilers'
@@ -305,7 +313,71 @@ pipeline {
                         unstash 'MathSetup'
                         dir('math') {
                             script {
-                                setupMakeLocal()
+                                setupMakeLocal("3", "clang", "clang++")
+                                runTests("test/unit/*_test.cpp", false)
+                                runTests("test/unit/math/*_test.cpp", false)
+                                runTests("test/unit/math/prim", true)
+                                runTests("test/unit/math/memory", false)
+                            }
+                        }
+
+                    }
+                    post { always { retry(3) { deleteDir() } } }
+                }
+                stage('Rev/Fwd Unit Tests - GCC') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:bleeding-edge-compilers'
+                            label 'linux'
+                            args '--pull always --cap-add SYS_PTRACE'
+                        }
+                    }
+                    steps {
+                        unstash 'MathSetup'
+                        dir('math') {
+                            script {
+                                setupMakeLocal("3", "gcc", "gcc++")
+                                runTests("test/unit/math/rev")
+                                runTests("test/unit/math/fwd")
+                            }
+                        }
+
+                    }
+                    post { always { retry(3) { deleteDir() } } }
+                }
+                stage('Mix Unit Tests - GCC') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:bleeding-edge-compilers'
+                            label 'linux'
+                            args '--pull always --cap-add SYS_PTRACE'
+                        }
+                    }
+                    steps {
+                        unstash 'MathSetup'
+                        dir('math') {
+                            script {
+                                setupMakeLocal("3", "gcc", "gcc++")
+                                runTests("test/unit/math/mix", true)
+                            }
+                        }
+
+                    }
+                    post { always { retry(3) { deleteDir() } } }
+                }
+                stage('Prim Unit Tests - GCC') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:bleeding-edge-compilers'
+                            label 'linux'
+                            args '--pull always --cap-add SYS_PTRACE'
+                        }
+                    }
+                    steps {
+                        unstash 'MathSetup'
+                        dir('math') {
+                            script {
+                                setupMakeLocal("3", "gcc", "gcc++")
                                 runTests("test/unit/*_test.cpp", false)
                                 runTests("test/unit/math/*_test.cpp", false)
                                 runTests("test/unit/math/prim", true)
@@ -429,14 +501,143 @@ pipeline {
                     }
                     post { always { sh "rm -rf ${env.WORKSPACE}/compile-end-to-end-O=1/*" }}
                 }
+                stage("Compile tests - good at O=1 - GCC") {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:bleeding-edge-compilers'
+                            label 'linux'
+                            args '--pull always'
+                        }
+                    }
+                    steps {
+                        dir("${env.WORKSPACE}/compile-good-O1"){
+                            unstash "Stanc3Setup"
+                            script {
+                                runPerformanceTests("../test/integration/good", "--O1", "gcc")
+                            }
+
+                            xunit([GoogleTest(
+                                deleteOutputFiles: false,
+                                failIfNotNew: true,
+                                pattern: 'performance-tests-cmdstan/performance.xml',
+                                skipNoTestFiles: false,
+                                stopProcessingIfError: false)
+                            ])
+                        }
+                    }
+                    post { always { sh "rm -rf ${env.WORKSPACE}/compile-good-O1/*" }}
+                }
+
+                stage("Compile tests - example-models at O=1 - GCC") {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:bleeding-edge-compilers'
+                            label 'linux'
+                            args '--pull always'
+                        }
+                    }
+                    steps {
+                        dir("${env.WORKSPACE}/compile-example-O1"){
+                            script {
+                                unstash "Stanc3Setup"
+                                runPerformanceTests("example-models", "--O1", "gcc")
+                            }
+
+                            xunit([GoogleTest(
+                                deleteOutputFiles: false,
+                                failIfNotNew: true,
+                                pattern: 'performance-tests-cmdstan/performance.xml',
+                                skipNoTestFiles: false,
+                                stopProcessingIfError: false)
+                            ])
+                        }
+                    }
+                    post { always { sh "rm -rf ${env.WORKSPACE}/compile-example-O1/*" }}
+                }
+
+                stage("Model end-to-end - GCC") {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:bleeding-edge-compilers'
+                            label 'linux'
+                            args '--pull always'
+                        }
+                    }
+                    steps {
+                        dir("${env.WORKSPACE}/compile-end-to-end-O=1"){
+                            script {
+                                unstash "Stanc3Setup"
+                                unstash 'ubuntu-exe'
+                                sh """
+                                    git clone --recursive --depth 50 https://github.com/stan-dev/performance-tests-cmdstan
+                                """
+                                utils.checkout_pr("cmdstan", "performance-tests-cmdstan/cmdstan", params.cmdstan_pr)
+                                utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
+                                utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
+                                setupMakeLocal("3","gcc","gcc++","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
+                                sh """
+                                    cd performance-tests-cmdstan
+                                    git show HEAD --stat
+                                    echo "example-models/regression_tests/mother.stan" > all.tests
+                                    cat known_good_perf_all.tests >> all.tests
+                                    echo "" >> all.tests
+                                    cat shotgun_perf_all.tests >> all.tests
+                                    cat all.tests
+                                    echo "PRECOMPILED_HEADERS=false" >> cmdstan/make/local
+                                    pwd
+                                    cd cmdstan; make clean-all; git show HEAD --stat; make -j4 build
+                                    pwd
+                                    rm bin/stanc
+                                    cp ../../bin/stanc bin/stanc
+                                    make print-compiler-flags
+                                    make -j4 examples/bernoulli/bernoulli; ./bin/stanc --version; cd ..
+                                    echo "STANCFLAGS += --O1" >> cmdstan/make/local
+                                    ./runPerformanceTests.py --overwrite-golds --tests-file all.tests --num-samples=20
+                                """
+                            }
+
+                            xunit([GoogleTest(
+                                deleteOutputFiles: false,
+                                failIfNotNew: true,
+                                pattern: 'performance-tests-cmdstan/performance.xml',
+                                skipNoTestFiles: false,
+                                stopProcessingIfError: false)
+                            ])
+
+                            archiveArtifacts 'performance-tests-cmdstan/performance.xml'
+                        }
+                    }
+                    post { always { sh "rm -rf ${env.WORKSPACE}/compile-end-to-end-O=1/*" }}
+                }
             }
         }
 
         stage('CmdStan Perf Tests') {
             parallel {
-                stage("Numerical Accuracy and Performance Tests on Known-Good Models") {
-                    // This will error out on MAC M1 architecture
-                    agent { label 'osx && intel' }
+                stage('Numerical Accuracy and Performance Tests on Known-Good Models') {
+                        // This will error out on MAC M1 architecture
+                        agent { label 'osx && intel' }
+                        steps {
+                            unstash "PerfSetup"
+                            setupMakeLocal("0","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
+                            sh """
+                                python3 -m venv .venv
+                                source .venv/bin/activate
+                                python3 -m pip install statistics
+                                python3 runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests
+                            """
+                            junit '*.xml'
+                            archiveArtifacts '*.xml'
+                    }
+                }
+                stage('Shotgun Performance Regression Tests') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:bleeding-edge-compilers'
+                            label 'linux'
+                            args '--pull always'
+                        }
+                    }
                     steps {
                         unstash "PerfSetup"
                         setupMakeLocal("0","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
@@ -444,31 +645,45 @@ pipeline {
                             python3 -m venv .venv
                             source .venv/bin/activate
                             python3 -m pip install statistics
-                            python3 runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests
+                            python3 runPerformanceTests.py --runs 2 --name=shotgun_perf --tests-file=shotgun_perf_all.tests
                         """
-                        junit '*.xml'
-                        archiveArtifacts '*.xml'
-                }
-            }
-            stage('Shotgun Performance Regression Tests') {
-                agent {
-                    docker {
-                        image 'stanorg/ci:bleeding-edge-compilers'
-                        label 'linux'
-                        args '--pull always'
                     }
                 }
-                steps {
-                    unstash "PerfSetup"
-                    setupMakeLocal("0","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
-                    sh """
-                        python3 -m venv .venv
-                        source .venv/bin/activate
-                        python3 -m pip install statistics
-                        python3 runPerformanceTests.py --runs 2 --name=shotgun_perf --tests-file=shotgun_perf_all.tests
-                    """
+                stage('Numerical Accuracy and Performance Tests on Known-Good Models - GCC') {
+                        // This will error out on MAC M1 architecture
+                        agent { label 'osx && intel' }
+                        steps {
+                            unstash "PerfSetup"
+                            setupMakeLocal("0","gcc","gcc++","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
+                            sh """
+                                python3 -m venv .venv
+                                source .venv/bin/activate
+                                python3 -m pip install statistics
+                                python3 runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests
+                            """
+                            junit '*.xml'
+                            archiveArtifacts '*.xml'
+                    }
                 }
-            }
+                stage('Shotgun Performance Regression Tests - GCC') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:bleeding-edge-compilers'
+                            label 'linux'
+                            args '--pull always'
+                        }
+                    }
+                    steps {
+                        unstash "PerfSetup"
+                        setupMakeLocal("0","gcc","gcc++","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
+                        sh """
+                            python3 -m venv .venv
+                            source .venv/bin/activate
+                            python3 -m pip install statistics
+                            python3 runPerformanceTests.py --runs 2 --name=shotgun_perf --tests-file=shotgun_perf_all.tests
+                        """
+                    }
+                }
             }
         }
 

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -122,32 +122,32 @@ pipeline {
             }
         }
 
-        stage('Prepare math') {
-            agent {
-                docker {
-                    image 'alpine/git'
-                    label 'linux'
-                    args "--entrypoint=\'\'"
-                }
-            }
-            steps {
-                script {
-                    sh """
-                        rm -rf math
-                        git clone https://github.com/stan-dev/math.git
-                        cd math
-                        git checkout ${params.math_pr}
-                        git clean -xffd
-                    """
-                    stash 'MathSetup'
-                }
-            }
-            post {
-                always {
-                    deleteDir()
-                }
-            }
-        }
+        // stage('Prepare math') {
+        //     agent {
+        //         docker {
+        //             image 'alpine/git'
+        //             label 'linux'
+        //             args "--entrypoint=\'\'"
+        //         }
+        //     }
+        //     steps {
+        //         script {
+        //             sh """
+        //                 rm -rf math
+        //                 git clone https://github.com/stan-dev/math.git
+        //                 cd math
+        //                 git checkout ${params.math_pr}
+        //                 git clean -xffd
+        //             """
+        //             stash 'MathSetup'
+        //         }
+        //     }
+        //     post {
+        //         always {
+        //             deleteDir()
+        //         }
+        //     }
+        // }
 
         stage('Prepare Performance-Tests-Cmdstan') {
             agent {
@@ -182,56 +182,56 @@ pipeline {
             }
         }
 
-        stage('Prepare stanc3') {
-            agent {
-                docker {
-                    image 'alpine/git'
-                    label 'linux'
-                    args "--entrypoint=\'\'"
-                }
-            }
-            steps {
-                script {
-                    sh """
-                        rm -rf stanc3
-                        git clone https://github.com/stan-dev/stanc3.git
-                        cd stanc3
-                        git submodule update --init --recursive
-                        git checkout ${params.stanc3_pr}
-                        git clean -xffd
-                    """
+        // stage('Prepare stanc3') {
+        //     agent {
+        //         docker {
+        //             image 'alpine/git'
+        //             label 'linux'
+        //             args "--entrypoint=\'\'"
+        //         }
+        //     }
+        //     steps {
+        //         script {
+        //             sh """
+        //                 rm -rf stanc3
+        //                 git clone https://github.com/stan-dev/stanc3.git
+        //                 cd stanc3
+        //                 git submodule update --init --recursive
+        //                 git checkout ${params.stanc3_pr}
+        //                 git clean -xffd
+        //             """
 
-                    stash 'Stanc3Setup'
-                }
-            }
-            post {
-                always {
-                    deleteDir()
-                }
-            }
-        }
+        //             stash 'Stanc3Setup'
+        //         }
+        //     }
+        //     post {
+        //         always {
+        //             deleteDir()
+        //         }
+        //     }
+        // }
     
-        stage("Build Stanc3") {
-            agent {
-                docker {
-                    image 'stanorg/stanc3:debianfi'
-                    //Forces image to ignore entrypoint
-                    args "--entrypoint=\'\'"
-                    label 'linux'
-                }
-            }
-            steps {
-                unstash "Stanc3Setup"
-                sh"""
-                    eval \$(opam env)
-                    dune build @install
-                """
+        // stage("Build Stanc3") {
+        //     agent {
+        //         docker {
+        //             image 'stanorg/stanc3:debianfi'
+        //             //Forces image to ignore entrypoint
+        //             args "--entrypoint=\'\'"
+        //             label 'linux'
+        //         }
+        //     }
+        //     steps {
+        //         unstash "Stanc3Setup"
+        //         sh"""
+        //             eval \$(opam env)
+        //             dune build @install
+        //         """
 
-                sh "mkdir -p bin && mv _build/default/stanc3/src/stanc/stanc.exe bin/stanc"
-                stash name:'ubuntu-exe', includes:'bin/stanc, notes/working-models.txt'
-            }
-            post { always { sh "rm -rf ./*" }}
-        }
+        //         sh "mkdir -p bin && mv _build/default/stanc3/src/stanc/stanc.exe bin/stanc"
+        //         stash name:'ubuntu-exe', includes:'bin/stanc, notes/working-models.txt'
+        //     }
+        //     post { always { sh "rm -rf ./*" }}
+        // }
 
         // stage('Full Unit Tests') {
         //     failFast true

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -372,7 +372,6 @@ pipeline {
                             script {
                                 unstash "Stanc3Setup"
                                 unstash 'ubuntu-exe'
-                                sh "ls -lhart"
                                 sh """
                                     git clone --recursive --depth 50 https://github.com/stan-dev/performance-tests-cmdstan
                                 """
@@ -397,9 +396,7 @@ pipeline {
                                     make print-compiler-flags
                                     make -j4 examples/bernoulli/bernoulli; ./bin/stanc --version; cd ..
                                     echo "STANCFLAGS += --O1" >> cmdstan/make/local
-                                    pyenv install 3.8.10
-                                    pyenv global 3.8.10
-                                    python3 runPerformanceTests.py --overwrite-golds --tests-file all.tests --num-samples=10
+                                    ./runPerformanceTests.py --overwrite-golds --tests-file all.tests --num-samples=10
                                 """
                             }
 
@@ -427,7 +424,7 @@ pipeline {
                     steps {
                         unstash "PerfSetup"
                         setupMakeLocal("","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
-                        sh "python3 runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests"
+                        sh "./runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests"
                         junit '*.xml'
                         archiveArtifacts '*.xml'
                 }
@@ -443,7 +440,7 @@ pipeline {
                 steps {
                     unstash "PerfSetup"
                     setupMakeLocal("","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
-                    sh "python3 runPerformanceTests.py --runs 2 --name=shotgun_perf --tests-file=shotgun_perf_all.tests "
+                    sh "./runPerformanceTests.py --runs 2 --name=shotgun_perf --tests-file=shotgun_perf_all.tests "
                 }
             }
             }

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -21,7 +21,7 @@ def setupMakeLocal() {
         echo CXX="clang++" >> make/local
         echo CFLAGS="-stdlib=libc++" >> make/local
         echo CPPFLAGS="-nostdinc++ -nodefaultlibs -I/usr/local/include/c++/v1" >> make/local
-        echo CXXFLAGS="-fsanitize=address" >> make/local
+        echo CXXFLAGS="-nostdinc++ -nostdlib++ -I/usr/local/include/c++/v1 -fsanitize=address" >> make/local
         echo LDFLAGS="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1 -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc" >> make/local
     """
 }

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -32,6 +32,11 @@ def setupMakeLocal(String o = "3", String cc = "clang" , String cxx = "clang++" 
             echo LDFLAGS+="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc ${ldFlags}" >> ${makeLocalPath}
         """
     }
+    else {
+        sh """
+            echo LDFLAGS+="${ldFlags}" >> ${makeLocalPath}
+        """
+    }
     sh "${cxx} --version"
 }
 

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -425,7 +425,7 @@ pipeline {
                         unstash "PerfSetup"
                         setupMakeLocal("","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
                         sh """
-                            pip install statistics
+                            pip install statistics --break-system-packages
                             ./runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests
                         """
                         junit '*.xml'
@@ -444,7 +444,7 @@ pipeline {
                     unstash "PerfSetup"
                     setupMakeLocal("","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
                     sh """
-                        pip install statistics
+                        pip install statistics --break-system-packages
                         ./runPerformanceTests.py --runs 2 --name=shotgun_perf --tests-file=shotgun_perf_all.tests
                     """
                 }

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -17,11 +17,9 @@ def setupMakeLocal() {
         echo CC="clang" >> make/local
         echo CXX="clang++" >> make/local
         echo CFLAGS="-stdlib=libc++" >> make/local
-        echo CPPFLAGS="-nostdinc++ -nodefaultlibs -I/usr/local/include/c++/v1 -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc" >> make/local
-        echo CXXFLAGS="-fsanitize=address -nostdinc++ -nostdlib++ -I/usr/local/include/c++/v1 -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++" >> make/local
-        echo LDFLAGS="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1" >> make/local
-
-        cat make/local
+        echo CPPFLAGS="-nostdinc++ -nodefaultlibs -I/usr/local/include/c++/v1" >> make/local
+        echo CXXFLAGS="-fsanitize=address" >> make/local
+        echo LDFLAGS="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1 -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc" >> make/local
     """
 }
 
@@ -110,24 +108,6 @@ pipeline {
         stage('Full Unit Tests') {
             failFast true
             parallel {
-                stage('Run changed unit tests') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:bleeding-edge-compilers'
-                            label 'linux'
-                            args '--cap-add SYS_PTRACE'
-                        }
-                    }
-                    steps {
-                        unstash 'MathSetup'
-                        dir('math') {
-                            script{ setupMakeLocal() }
-                            sh "python3 runTests.py -j${PARALLEL} --changed --debug"
-                        }
-
-                    }
-                    post { always { retry(3) { deleteDir() } } }
-                }
                 stage('Rev/Fwd Unit Tests') {
                     agent {
                         docker {

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -310,6 +310,7 @@ pipeline {
                         docker {
                             image 'stanorg/ci:bleeding-edge-compilers'
                             label 'linux'
+                            args '--pull always'
                         }
                     }
                     steps {
@@ -336,6 +337,7 @@ pipeline {
                         docker {
                             image 'stanorg/ci:bleeding-edge-compilers'
                             label 'linux'
+                            args '--pull always'
                         }
                     }
                     steps {
@@ -362,6 +364,7 @@ pipeline {
                         docker {
                             image 'stanorg/ci:bleeding-edge-compilers'
                             label 'linux'
+                            args '--pull always'
                         }
                     }
                     steps {

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -1,6 +1,11 @@
 #!/usr/bin/env groovy
+
 @Library('StanUtils')
 import org.stan.Utils
+
+utils = new org.stan.Utils()
+
+String stanc3_bin_url() { params.stanc3_bin_url != "nightly" ? "\nSTANC3_TEST_BIN_URL=${params.stanc3_bin_url}\n" : "" }
 
 def runTests(String testPath, boolean jumbo = false) {
     try {
@@ -13,20 +18,50 @@ def runTests(String testPath, boolean jumbo = false) {
     finally { junit 'test/**/*.xml' }
 }
 
-def setupMakeLocal() {
+def setupMakeLocal(String o = "", String cc = "" , String cxx = "" , String cFlags = "", String cppFlags = "", String cxxFlags = "", String ldFlags = "", String makeLocalPath = "make/local") {
     // When ready, change O=3
     sh """
-        echo O=0 >> make/local
-        echo CC="clang" >> make/local
-        echo CXX="clang++" >> make/local
-        echo CFLAGS="-stdlib=libc++" >> make/local
-        echo CPPFLAGS="-nostdinc++ -nodefaultlibs -I/usr/local/include/c++/v1" >> make/local
-        echo CXXFLAGS="-nostdinc++ -nostdlib++ -I/usr/local/include/c++/v1 -fsanitize=address" >> make/local
-        echo LDFLAGS="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc" >> make/local
+        echo O="0 ${o}" >> ${makeLocalPath}
+        echo CC="clang ${cc}" >> ${makeLocalPath}
+        echo CXX="clang++ ${cxx}" >> ${makeLocalPath}
+        echo CFLAGS="-stdlib=libc++ ${cFlags}" >> ${makeLocalPath}
+        echo CPPFLAGS="-nostdinc++ -nodefaultlibs -I/usr/local/include/c++/v1 ${cppFlags}" >> ${makeLocalPath}
+        echo CXXFLAGS="-nostdinc++ -nostdlib++ -I/usr/local/include/c++/v1 -fsanitize=address ${cxxFlags}" >> ${makeLocalPath}
+        echo LDFLAGS="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc ${ldFlags}" >> ${makeLocalPath}
     """
 }
 
-def utils = new org.stan.Utils()
+def runPerformanceTests(String testsPath, String stancFlags = ""){
+    unstash 'ubuntu-exe'
+
+    sh """
+        git clone --recursive --depth 50 https://github.com/stan-dev/performance-tests-cmdstan
+    """
+
+    writeFile(file:"performance-tests-cmdstan/cmdstan/make/local", text:"CXX=clang++")
+
+    utils.checkout_pr("cmdstan", "performance-tests-cmdstan/cmdstan", params.cmdstan_pr)
+    utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
+    utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
+
+    sh """
+        cd performance-tests-cmdstan
+        mkdir cmdstan/bin
+        cp ../bin/stanc cmdstan/bin/linux-stanc
+        cd cmdstan; make clean-all;
+    """
+
+    if (stancFlags?.trim()) {
+        sh "cd performance-tests-cmdstan/cmdstan && echo 'STANCFLAGS= $stancFlags' >> make/local"
+    }
+
+    sh """
+        cd performance-tests-cmdstan/cmdstan
+        echo 'O=0' >> make/local
+        make -j${env.PARALLEL} build; cd ..
+        ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 ${testsPath}
+    """
+}
 
 pipeline {
     agent none
@@ -37,7 +72,15 @@ pipeline {
     }
     parameters {
         booleanParam(defaultValue: false, name: 'buildDocker', description: 'Build docker image with latest gcc, clang')
-        string(defaultValue: 'develop', name: 'mathBranch', description: 'What match branch to clone')
+        string(defaultValue: 'nightly', name: 'stanc3_bin_url', description: 'Custom stanc3 binary url')
+        string(defaultValue: 'develop', name: 'cmdstan_pr',
+               description: "CmdStan PR to test against. Will check out this PR in the downstream Stan repo.")
+        string(defaultValue: 'develop', name: 'stan_pr',
+               description: "Stan PR to test against. Will check out this PR in the downstream Stan repo.")
+        string(defaultValue: 'develop', name: 'math_pr',
+               description: "Math PR to test against. Will check out this PR in the downstream Math repo.")
+        string(defaultValue: 'master', name: 'stanc3_pr',
+               description: "Stanc3 PR to test against. Will check out this PR in the downstream Math repo.")
     }
     environment {
         STAN_NUM_THREADS = 4
@@ -79,7 +122,6 @@ pipeline {
             }
         }
 
-
         stage('Prepare math') {
             agent {
                 docker {
@@ -94,7 +136,7 @@ pipeline {
                         rm -rf math
                         git clone https://github.com/stan-dev/math.git
                         cd math
-                        git checkout ${params.mathBranch}
+                        git checkout ${params.math_pr}
                         git clean -xffd
                     """
                     stash 'MathSetup'
@@ -105,6 +147,90 @@ pipeline {
                     deleteDir()
                 }
             }
+        }
+
+        stage('Prepare Performance-Tests-Cmdstan') {
+            agent {
+                docker {
+                    image 'alpine/git'
+                    label 'linux'
+                    args "--entrypoint=\'\'"
+                }
+            }
+            steps {
+                deleteDir()
+                checkout([$class: 'GitSCM',
+                          branches: [[name: '*/master']],
+                          doGenerateSubmoduleConfigurations: false,
+                          extensions: [[$class: 'SubmoduleOption',
+                                        disableSubmodules: false,
+                                        parentCredentials: false,
+                                        recursiveSubmodules: true,
+                                        reference: '',
+                                        trackingSubmodules: false]],
+                          submoduleCfg: [],
+                          userRemoteConfigs: [[url: "https://github.com/stan-dev/performance-tests-cmdstan.git",
+                                               credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b'
+                    ]]])
+
+                stash 'PerfSetup'
+            }
+            post {
+                always {
+                    deleteDir()
+                }
+            }
+        }
+
+        stage('Prepare stanc3') {
+            agent {
+                docker {
+                    image 'alpine/git'
+                    label 'linux'
+                    args "--entrypoint=\'\'"
+                }
+            }
+            steps {
+                script {
+                    sh """
+                        rm -rf stanc3
+                        git clone https://github.com/stan-dev/stanc3.git
+                        cd stanc3
+                        git submodule update --init --recursive
+                        git checkout ${params.stanc3_pr}
+                        git clean -xffd
+                    """
+
+                    stash 'Stanc3Setup'
+                }
+            }
+            post {
+                always {
+                    deleteDir()
+                }
+            }
+        }
+    
+        stage("Build Stanc3") {
+            agent {
+                docker {
+                    image 'stanorg/stanc3:debianfi'
+                    //Forces image to ignore entrypoint
+                    args "--entrypoint=\'\'"
+                    label 'linux'
+                }
+            }
+            steps {
+                unstash "Stanc3Setup"
+                sh"""
+                    eval \$(opam env)
+                    dune build @install
+                """
+
+                sh "mkdir -p bin && mv _build/default/stanc3/src/stanc/stanc.exe bin/stanc"
+                stash name:'ubuntu-exe', includes:'bin/stanc, notes/working-models.txt'
+            }
+            post { always { sh "rm -rf ./*" }}
         }
 
         stage('Full Unit Tests') {
@@ -173,6 +299,178 @@ pipeline {
 
                     }
                     post { always { retry(3) { deleteDir() } } }
+                }
+            }
+        }
+
+        stage('CmdStan Perf Tests') {
+            parallel {
+                stage("Numerical Accuracy and Performance Tests on Known-Good Models") {
+                    agent { label 'osx && intel' }
+                    steps {
+                        unstash "PerfSetup"
+                        setupMakeLocal("","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
+                        sh "python3 runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests"
+                        junit '*.xml'
+                        archiveArtifacts '*.xml'
+                }
+            }
+            stage('Shotgun Performance Regression Tests') {
+                agent {
+                    docker {
+                        image 'stanorg/ci:bleeding-edge-compilers'
+                        label 'linux'
+                        args '--pull always'
+                    }
+                }
+                steps {
+                    unstash "PerfSetup"
+                    setupMakeLocal("","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
+                    sh "python3 runPerformanceTests.py --runs 2 --name=shotgun_perf --tests-file=shotgun_perf_all.tests "
+                }
+            }
+            }
+        }
+
+        stage("CmdStan & Math tests") {
+            parallel {
+                stage("Compile tests - good at O=1") {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:bleeding-edge-compilers'
+                            label 'linux'
+                        }
+                    }
+                    steps {
+                        dir("${env.WORKSPACE}/compile-good-O1"){
+                            unstash "Stanc3Setup"
+                            script {
+                                runPerformanceTests("../test/integration/good", "--O1")
+                            }
+
+                            xunit([GoogleTest(
+                                deleteOutputFiles: false,
+                                failIfNotNew: true,
+                                pattern: 'performance-tests-cmdstan/performance.xml',
+                                skipNoTestFiles: false,
+                                stopProcessingIfError: false)
+                            ])
+                        }
+                    }
+                    post { always { sh "rm -rf ${env.WORKSPACE}/compile-good-O1/*" }}
+                }
+
+                stage("Compile tests - example-models at O=1") {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:bleeding-edge-compilers'
+                            label 'linux'
+                        }
+                    }
+                    steps {
+                        dir("${env.WORKSPACE}/compile-example-O1"){
+                            script {
+                                unstash "Stanc3Setup"
+                                runPerformanceTests("example-models", "--O1")
+                            }
+
+                            xunit([GoogleTest(
+                                deleteOutputFiles: false,
+                                failIfNotNew: true,
+                                pattern: 'performance-tests-cmdstan/performance.xml',
+                                skipNoTestFiles: false,
+                                stopProcessingIfError: false)
+                            ])
+                        }
+                    }
+                    post { always { sh "rm -rf ${env.WORKSPACE}/compile-example-O1/*" }}
+                }
+
+                stage("Model end-to-end tests at O=1") {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:bleeding-edge-compilers'
+                            label 'linux'
+                        }
+                    }
+                    steps {
+                        dir("${env.WORKSPACE}/compile-end-to-end-O=1"){
+                            script {
+                                unstash "Stanc3Setup"
+                                unstash 'ubuntu-exe'
+                                sh """
+                                    git clone --recursive --depth 50 https://github.com/stan-dev/performance-tests-cmdstan
+                                """
+                                utils.checkout_pr("cmdstan", "performance-tests-cmdstan/cmdstan", params.cmdstan_pr)
+                                utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
+                                utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
+                                setupMakeLocal("","","","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
+                                sh """
+                                    cd performance-tests-cmdstan
+                                    git show HEAD --stat
+                                    echo "example-models/regression_tests/mother.stan" > all.tests
+                                    cat known_good_perf_all.tests >> all.tests
+                                    echo "" >> all.tests
+                                    cat shotgun_perf_all.tests >> all.tests
+                                    cat all.tests
+                                    echo "PRECOMPILED_HEADERS=false" >> cmdstan/make/local
+                                    cd cmdstan; make clean-all; git show HEAD --stat; cd ..
+                                    CXX="clang++" ./compare-optimizer.sh "--tests-file all.tests --num-samples=10" "--O1" "\$(readlink -f ../bin/stanc)"
+                                """
+                            }
+
+                            xunit([GoogleTest(
+                                deleteOutputFiles: false,
+                                failIfNotNew: true,
+                                pattern: 'performance-tests-cmdstan/performance.xml',
+                                skipNoTestFiles: false,
+                                stopProcessingIfError: false)
+                            ])
+
+                            archiveArtifacts 'performance-tests-cmdstan/performance.xml'
+                        }
+                    }
+                    post { always { sh "rm -rf ${env.WORKSPACE}/compile-end-to-end-O=1/*" }}
+                }
+                stage('Math functions expressions test') {
+                    agent {
+                        docker {
+                            image 'stanorg/ci:bleeding-edge-compilers'
+                            label 'linux'
+                        }
+                    }
+                    steps {
+                        dir("${env.WORKSPACE}/compile-expressions"){
+                            unstash "Stanc3Setup"
+                            unstash 'ubuntu-exe'
+                            script {
+                                sh """
+                                    git clone --recursive https://github.com/stan-dev/math.git
+                                """
+                                utils.checkout_pr("math", "math", params.math_pr)
+                                sh """
+                                    cp bin/stanc math/test/expressions/stanc
+                                """
+
+                                dir("math") {
+                                    sh """
+                                        #!/usr/bin/env bash
+                                        echo O=0 >> make/local
+                                        echo "CXX=clang++ -Werror " >> make/local
+                                        # Fix for AttributeError: module 'collections' has no attribute 'Iterable'
+                                        # https://stackoverflow.com/questions/72371859/attributeerror-module-collections-has-no-attribute-iterable
+                                        # We might want to patch this in the main repository
+                                        sed -i 's/import collections/import collections\\ncollections.Iterable = collections.abc.Iterable/' test/code_generator.py
+                                    """
+                                    withEnv(['PATH+TBB=./lib/tbb']) {
+                                        try { sh "python3 runTests.py -j${env.PARALLEL} test/expressions" }
+                                        finally { junit 'test/**/*.xml' }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    post { always { sh "rm -rf ${env.WORKSPACE}/compile-expressions/*" }}
                 }
             }
         }

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -397,7 +397,8 @@ pipeline {
                                     make print-compiler-flags
                                     make -j4 examples/bernoulli/bernoulli; ./bin/stanc --version; cd ..
                                     echo "STANCFLAGS += --O1" >> cmdstan/make/local
-                                    pip3 install -U Pillow --break-system-packages
+                                    pyenv install 3.8.10
+                                    pyenv global 3.8.10
                                     python3 runPerformanceTests.py --overwrite-golds --tests-file all.tests --num-samples=10
                                 """
                             }

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -32,7 +32,7 @@ def setupMakeLocal(String o = "3", String cc = "clang" , String cxx = "clang++" 
             echo LDFLAGS+="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc ${ldFlags}" >> ${makeLocalPath}
         """
     }
-    sh "$CXX --version"
+    sh "\$CXX --version"
 }
 
 def runPerformanceTests(String testsPath, String stancFlags = "", String compiler = "clang"){

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -2,10 +2,13 @@
 @Library('StanUtils')
 import org.stan.Utils
 
-// How do we pass 
 def runTests(String testPath, boolean jumbo = false) {
     try {
-        sh "python3 runTests.py -j${env.PARALLEL} ${testPath}"
+        if (jumbo && !params.disableJumbo) {
+            sh "python3 runTests.py -j${env.PARALLEL} ${testPath} --jumbo --debug"
+        } else {
+            sh "python3 runTests.py -j${env.PARALLEL} ${testPath}"
+        }
     }
     finally { junit 'test/**/*.xml' }
 }

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -84,7 +84,7 @@ pipeline {
     environment {
         STAN_NUM_THREADS = 4
         N_TESTS = 100
-        PARALLEL = 1 // Change to 4 when ready
+        PARALLEL = 4
         GCC = 'g++'
     }
     stages {
@@ -117,6 +117,23 @@ pipeline {
             post {
                 always {
                     deleteDir()
+                }
+            }
+        }
+
+        stage('Pull latest docker image') {
+            parallel {
+                stage('Rev/Fwd Unit Tests') {
+                    agent { label 'linux && v100' }
+                    steps {
+                        sh "docker pull stanorg/ci:bleeding-edge-compilers"
+                    }
+                }
+                stage('Mix Unit Tests') {
+                    agent { label 'linux && k40' }
+                    steps {
+                        sh "docker pull stanorg/ci:bleeding-edge-compilers"
+                    }
                 }
             }
         }

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -397,7 +397,7 @@ pipeline {
                                     make print-compiler-flags
                                     make -j4 examples/bernoulli/bernoulli; ./bin/stanc --version; cd ..
                                     echo "STANCFLAGS += --O1" >> cmdstan/make/local
-                                    pip3 install -U Pillow
+                                    pip3 install -U Pillow --break-system-packages
                                     python3 runPerformanceTests.py --overwrite-golds --tests-file all.tests --num-samples=10
                                 """
                             }

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -20,9 +20,9 @@ def setupMakeLocal() {
         echo CC="clang" >> make/local
         echo CXX="clang++" >> make/local
         echo CFLAGS="-stdlib=libc++" >> make/local
-        echo CPPFLAGS="-nostdinc++ -nodefaultlibs -I/usr/local/include/c++/v1 -L/usr/local/lib -Wl,-rpath,/usr/local/lib" >> make/local
-        echo CXXFLAGS="-nostdinc++ -nostdlib++ -I/usr/local/include/c++/v1 -fsanitize=address -L/usr/local/lib -Wl,-rpath,/usr/local/lib" >> make/local
-        echo LDFLAGS="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1 -lc++ -lc++abi -lm -lc -lgcc_s -lgcc" >> make/local
+        echo CPPFLAGS="-nostdinc++ -nodefaultlibs -I/usr/local/include/c++/v1 -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc" >> make/local
+        echo CXXFLAGS="-fsanitize=address -nostdinc++ -nostdlib++ -I/usr/local/include/c++/v1 -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++" >> make/local
+        echo LDFLAGS="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1" >> make/local
     """
 }
 

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -38,11 +38,11 @@ def runPerformanceTests(String testsPath, String stancFlags = ""){
         git clone --recursive --depth 50 https://github.com/stan-dev/performance-tests-cmdstan
     """
 
-    writeFile(file:"performance-tests-cmdstan/cmdstan/make/local", text:"CXX=clang++")
-
     utils.checkout_pr("cmdstan", "performance-tests-cmdstan/cmdstan", params.cmdstan_pr)
     utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
     utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
+
+    setupMakeLocal("","","","","","", "-ltbb", "performance-tests-cmdstan/cmdstan/make/local")
 
     sh """
         cd performance-tests-cmdstan
@@ -394,6 +394,7 @@ pipeline {
                                     pwd
                                     rm bin/stanc
                                     cp ../../bin/stanc bin/stanc
+                                    make print-compiler-flags
                                     make -j4 examples/bernoulli/bernoulli; ./bin/stanc --version; cd ..
                                     echo "STANCFLAGS += --O1" >> cmdstan/make/local
                                     python3 runPerformanceTests.py --overwrite-golds --tests-file all.tests --num-samples=10

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -24,10 +24,10 @@ def setupMakeLocal(String o = "", String cc = "" , String cxx = "" , String cFla
         echo O="0 ${o}" >> ${makeLocalPath}
         echo CC="clang ${cc}" >> ${makeLocalPath}
         echo CXX="clang++ ${cxx}" >> ${makeLocalPath}
-        echo CFLAGS="-stdlib=libc++ ${cFlags}" >> ${makeLocalPath}
-        echo CPPFLAGS="-nostdinc++ -nodefaultlibs -I/usr/local/include/c++/v1 ${cppFlags}" >> ${makeLocalPath}
-        echo CXXFLAGS="-nostdinc++ -nostdlib++ -I/usr/local/include/c++/v1 -fsanitize=address ${cxxFlags}" >> ${makeLocalPath}
-        echo LDFLAGS="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc ${ldFlags}" >> ${makeLocalPath}
+        echo CFLAGS+="-stdlib=libc++ ${cFlags}" >> ${makeLocalPath}
+        echo CPPFLAGS+="-nostdinc++ -nodefaultlibs -I/usr/local/include/c++/v1 ${cppFlags}" >> ${makeLocalPath}
+        echo CXXFLAGS+="-nostdinc++ -nostdlib++ -I/usr/local/include/c++/v1 -fsanitize=address ${cxxFlags}" >> ${makeLocalPath}
+        echo LDFLAGS+="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -ltbb -lgcc ${ldFlags}" >> ${makeLocalPath}
     """
 }
 

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -46,7 +46,7 @@ def runPerformanceTests(String testsPath, String stancFlags = "", String compile
     utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
 
     if (compiler == "gcc"){
-        setupMakeLocal("0","gcc","gcc++","","","", "-ltbb", "performance-tests-cmdstan/cmdstan/make/local")
+        setupMakeLocal("0","gcc","g++","","","", "-ltbb", "performance-tests-cmdstan/cmdstan/make/local")
     }
     else if (compiler == "clang"){
         setupMakeLocal("0","clang","clang++","","","", "-ltbb", "performance-tests-cmdstan/cmdstan/make/local")
@@ -336,7 +336,7 @@ pipeline {
                         unstash 'MathSetup'
                         dir('math') {
                             script {
-                                setupMakeLocal("3", "gcc", "gcc++")
+                                setupMakeLocal("3", "gcc", "g++")
                                 runTests("test/unit/math/rev")
                                 runTests("test/unit/math/fwd")
                             }
@@ -357,7 +357,7 @@ pipeline {
                         unstash 'MathSetup'
                         dir('math') {
                             script {
-                                setupMakeLocal("3", "gcc", "gcc++")
+                                setupMakeLocal("3", "gcc", "g++")
                                 runTests("test/unit/math/mix", true)
                             }
                         }
@@ -377,7 +377,7 @@ pipeline {
                         unstash 'MathSetup'
                         dir('math') {
                             script {
-                                setupMakeLocal("3", "gcc", "gcc++")
+                                setupMakeLocal("3", "gcc", "g++")
                                 runTests("test/unit/*_test.cpp", false)
                                 runTests("test/unit/math/*_test.cpp", false)
                                 runTests("test/unit/math/prim", true)
@@ -574,7 +574,7 @@ pipeline {
                                 utils.checkout_pr("cmdstan", "performance-tests-cmdstan/cmdstan", params.cmdstan_pr)
                                 utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
                                 utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
-                                setupMakeLocal("3","gcc","gcc++","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
+                                setupMakeLocal("3","gcc","g++","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
                                 sh """
                                     cd performance-tests-cmdstan
                                     git show HEAD --stat
@@ -654,7 +654,7 @@ pipeline {
                         agent { label 'osx && intel' }
                         steps {
                             unstash "PerfSetup"
-                            setupMakeLocal("0","gcc","gcc++","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
+                            setupMakeLocal("0","gcc","g++","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
                             sh """
                                 python3 -m venv .venv
                                 source .venv/bin/activate
@@ -675,7 +675,7 @@ pipeline {
                     }
                     steps {
                         unstash "PerfSetup"
-                        setupMakeLocal("0","gcc","gcc++","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
+                        setupMakeLocal("0","gcc","g++","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
                         sh """
                             python3 -m venv .venv
                             source .venv/bin/activate

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -397,6 +397,7 @@ pipeline {
                                     make print-compiler-flags
                                     make -j4 examples/bernoulli/bernoulli; ./bin/stanc --version; cd ..
                                     echo "STANCFLAGS += --O1" >> cmdstan/make/local
+                                    pip3 install -U Pillow
                                     python3 runPerformanceTests.py --overwrite-golds --tests-file all.tests --num-samples=10
                                 """
                             }

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -76,7 +76,6 @@ pipeline {
     options {
         skipDefaultCheckout()
         preserveStashes(buildCount: 7)
-        parallelsAlwaysFailFast()
     }
     parameters {
         booleanParam(defaultValue: false, name: 'buildDocker', description: 'Build docker image with latest gcc, clang')

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -404,7 +404,7 @@ pipeline {
                 expression { params.run_cmdstan_math_tests }
             }
             parallel {
-                stage("Compile tests - good at O=1") {
+                stage("Compile tests - good at O=1 - CLANG") {
                     agent {
                         docker {
                             image 'stanorg/ci:bleeding-edge-compilers'
@@ -416,7 +416,7 @@ pipeline {
                         dir("${env.WORKSPACE}/compile-good-O1"){
                             unstash "Stanc3Setup"
                             script {
-                                runPerformanceTests("../test/integration/good", "--O1")
+                                runPerformanceTests("../test/integration/good", "--O1", "clang")
                             }
 
                             xunit([GoogleTest(
@@ -431,7 +431,7 @@ pipeline {
                     post { always { sh "rm -rf ${env.WORKSPACE}/compile-good-O1/*" }}
                 }
 
-                stage("Compile tests - example-models at O=1") {
+                stage("Compile tests - example-models at O=1 - CLANG") {
                     agent {
                         docker {
                             image 'stanorg/ci:bleeding-edge-compilers'
@@ -443,7 +443,7 @@ pipeline {
                         dir("${env.WORKSPACE}/compile-example-O1"){
                             script {
                                 unstash "Stanc3Setup"
-                                runPerformanceTests("example-models", "--O1")
+                                runPerformanceTests("example-models", "--O1", "clang")
                             }
 
                             xunit([GoogleTest(
@@ -458,7 +458,7 @@ pipeline {
                     post { always { sh "rm -rf ${env.WORKSPACE}/compile-example-O1/*" }}
                 }
 
-                stage("Model end-to-end") {
+                stage("Model end-to-end - CLANG") {
                     agent {
                         docker {
                             image 'stanorg/ci:bleeding-edge-compilers'
@@ -477,7 +477,7 @@ pipeline {
                                 utils.checkout_pr("cmdstan", "performance-tests-cmdstan/cmdstan", params.cmdstan_pr)
                                 utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
                                 utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
-                                setupMakeLocal("3","","","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
+                                setupMakeLocal("3","clang", "clang++","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
                                 sh """
                                     cd performance-tests-cmdstan
                                     git show HEAD --stat
@@ -629,12 +629,12 @@ pipeline {
                 expression { params.run_cmdstan_perf_tests }
             }
             parallel {
-                stage('Numerical Accuracy and Performance Tests on Known-Good Models') {
+                stage('Numerical Accuracy and Performance Tests on Known-Good Models - CLANG') {
                         // This will error out on MAC M1 architecture
                         agent { label 'osx && intel' }
                         steps {
                             unstash "PerfSetup"
-                            setupMakeLocal("0","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
+                            setupMakeLocal("0","clang","clang++","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
                             sh """
                                 python3 -m venv .venv
                                 source .venv/bin/activate
@@ -645,7 +645,7 @@ pipeline {
                             archiveArtifacts '*.xml'
                     }
                 }
-                stage('Shotgun Performance Regression Tests') {
+                stage('Shotgun Performance Regression Tests - CLANG') {
                     agent {
                         docker {
                             image 'stanorg/ci:bleeding-edge-compilers'
@@ -655,7 +655,7 @@ pipeline {
                     }
                     steps {
                         unstash "PerfSetup"
-                        setupMakeLocal("0","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
+                        setupMakeLocal("0","clang","clang++","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
                         sh """
                             python3 -m venv .venv
                             source .venv/bin/activate

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -233,75 +233,75 @@ pipeline {
             post { always { sh "rm -rf ./*" }}
         }
 
-        stage('Full Unit Tests') {
-            failFast true
-            parallel {
-                stage('Rev/Fwd Unit Tests') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:bleeding-edge-compilers'
-                            label 'linux'
-                            args '--pull always --cap-add SYS_PTRACE'
-                        }
-                    }
-                    steps {
-                        unstash 'MathSetup'
-                        dir('math') {
-                            script {
-                                setupMakeLocal()
-                                runTests("test/unit/math/rev")
-                                runTests("test/unit/math/fwd")
-                            }
-                        }
+        // stage('Full Unit Tests') {
+        //     failFast true
+        //     parallel {
+        //         stage('Rev/Fwd Unit Tests') {
+        //             agent {
+        //                 docker {
+        //                     image 'stanorg/ci:bleeding-edge-compilers'
+        //                     label 'linux'
+        //                     args '--pull always --cap-add SYS_PTRACE'
+        //                 }
+        //             }
+        //             steps {
+        //                 unstash 'MathSetup'
+        //                 dir('math') {
+        //                     script {
+        //                         setupMakeLocal()
+        //                         runTests("test/unit/math/rev")
+        //                         runTests("test/unit/math/fwd")
+        //                     }
+        //                 }
 
-                    }
-                    post { always { retry(3) { deleteDir() } } }
-                }
-                stage('Mix Unit Tests') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:bleeding-edge-compilers'
-                            label 'linux'
-                            args '--pull always --cap-add SYS_PTRACE'
-                        }
-                    }
-                    steps {
-                        unstash 'MathSetup'
-                        dir('math') {
-                            script {
-                                setupMakeLocal()
-                                runTests("test/unit/math/mix", true)
-                            }
-                        }
+        //             }
+        //             post { always { retry(3) { deleteDir() } } }
+        //         }
+        //         stage('Mix Unit Tests') {
+        //             agent {
+        //                 docker {
+        //                     image 'stanorg/ci:bleeding-edge-compilers'
+        //                     label 'linux'
+        //                     args '--pull always --cap-add SYS_PTRACE'
+        //                 }
+        //             }
+        //             steps {
+        //                 unstash 'MathSetup'
+        //                 dir('math') {
+        //                     script {
+        //                         setupMakeLocal()
+        //                         runTests("test/unit/math/mix", true)
+        //                     }
+        //                 }
 
-                    }
-                    post { always { retry(3) { deleteDir() } } }
-                }
-                stage('Prim Unit Tests') {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:bleeding-edge-compilers'
-                            label 'linux'
-                            args '--pull always --cap-add SYS_PTRACE'
-                        }
-                    }
-                    steps {
-                        unstash 'MathSetup'
-                        dir('math') {
-                            script {
-                                setupMakeLocal()
-                                runTests("test/unit/*_test.cpp", false)
-                                runTests("test/unit/math/*_test.cpp", false)
-                                runTests("test/unit/math/prim", true)
-                                runTests("test/unit/math/memory", false)
-                            }
-                        }
+        //             }
+        //             post { always { retry(3) { deleteDir() } } }
+        //         }
+        //         stage('Prim Unit Tests') {
+        //             agent {
+        //                 docker {
+        //                     image 'stanorg/ci:bleeding-edge-compilers'
+        //                     label 'linux'
+        //                     args '--pull always --cap-add SYS_PTRACE'
+        //                 }
+        //             }
+        //             steps {
+        //                 unstash 'MathSetup'
+        //                 dir('math') {
+        //                     script {
+        //                         setupMakeLocal()
+        //                         runTests("test/unit/*_test.cpp", false)
+        //                         runTests("test/unit/math/*_test.cpp", false)
+        //                         runTests("test/unit/math/prim", true)
+        //                         runTests("test/unit/math/memory", false)
+        //                     }
+        //                 }
 
-                    }
-                    post { always { retry(3) { deleteDir() } } }
-                }
-            }
-        }
+        //             }
+        //             post { always { retry(3) { deleteDir() } } }
+        //         }
+        //     }
+        // }
 
         stage("CmdStan & Math tests") {
             parallel {
@@ -386,6 +386,8 @@ pipeline {
                                     cat all.tests
                                     echo "PRECOMPILED_HEADERS=false" >> cmdstan/make/local
                                     cd cmdstan; make clean-all; git show HEAD --stat; cd ..
+                                    chmod +x runPerformanceTests.py
+                                    chmod +x compare-optimizer.sh
                                     CXX="clang++" ./compare-optimizer.sh "--tests-file all.tests --num-samples=10" "--O1" "\$(readlink -f ../bin/stanc)"
                                 """
                             }

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -393,7 +393,7 @@ pipeline {
                                     cd cmdstan; make clean-all; git show HEAD --stat; make -j4 build
                                     pwd
                                     rm bin/stanc
-                                    cp ../bin/stanc bin/stanc
+                                    cp ../../bin/stanc bin/stanc
                                     make -j4 examples/bernoulli/bernoulli; ./bin/stanc --version; cd ..
                                     echo "STANCFLAGS += --O1" >> cmdstan/make/local
                                     CXX="clang++" python3 runPerformanceTests.py --overwrite-golds --tests-file all.tests --num-samples=10

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -59,7 +59,7 @@ def runPerformanceTests(String testsPath, String stancFlags = ""){
         cd performance-tests-cmdstan/cmdstan
         echo 'O=0' >> make/local
         make -j${env.PARALLEL} build; cd ..
-        ./runPerformanceTests.py -j${env.PARALLEL} --runs=0 ${testsPath}
+        python3 runPerformanceTests.py -j${env.PARALLEL} --runs=0 ${testsPath}
     """
 }
 

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -5,8 +5,6 @@ import org.stan.Utils
 
 utils = new org.stan.Utils()
 
-String stanc3_bin_url() { params.stanc3_bin_url != "nightly" ? "\nSTANC3_TEST_BIN_URL=${params.stanc3_bin_url}\n" : "" }
-
 def runTests(String testPath, boolean jumbo = false) {
     try {
         if (jumbo && !params.disableJumbo) {
@@ -80,7 +78,6 @@ pipeline {
     }
     parameters {
         booleanParam(defaultValue: false, name: 'buildDocker', description: 'Build docker image with latest gcc, clang')
-        string(defaultValue: 'nightly', name: 'stanc3_bin_url', description: 'Custom stanc3 binary url')
         string(defaultValue: 'develop', name: 'cmdstan_pr',
                description: "CmdStan PR to test against. Will check out this PR in the downstream Stan repo.")
         string(defaultValue: 'develop', name: 'stan_pr',

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -387,6 +387,8 @@ pipeline {
                                     echo "PRECOMPILED_HEADERS=false" >> cmdstan/make/local
                                     cd cmdstan; make clean-all; git show HEAD --stat; cd ..
                                     alias python="python3 "
+                                    dos2unix runPerformanceTests.py
+                                    chmod +x runPerformanceTests.py
                                     CXX="clang++" ./compare-optimizer.sh "--tests-file all.tests --num-samples=10" "--O1" "\$(readlink -f ../bin/stanc)"
                                 """
                             }

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -27,7 +27,7 @@ def setupMakeLocal(String o = "", String cc = "" , String cxx = "" , String cFla
         echo CFLAGS+="-stdlib=libc++ ${cFlags}" >> ${makeLocalPath}
         echo CPPFLAGS+="-nostdinc++ -nodefaultlibs -I/usr/local/include/c++/v1 ${cppFlags}" >> ${makeLocalPath}
         echo CXXFLAGS+="-nostdinc++ -nostdlib++ -I/usr/local/include/c++/v1 -fsanitize=address ${cxxFlags}" >> ${makeLocalPath}
-        echo LDFLAGS+="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -ltbb -lgcc ${ldFlags}" >> ${makeLocalPath}
+        echo LDFLAGS+="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc ${ldFlags}" >> ${makeLocalPath}
     """
 }
 
@@ -396,7 +396,7 @@ pipeline {
                                     cp ../../bin/stanc bin/stanc
                                     make -j4 examples/bernoulli/bernoulli; ./bin/stanc --version; cd ..
                                     echo "STANCFLAGS += --O1" >> cmdstan/make/local
-                                    CXX="clang++" python3 runPerformanceTests.py --overwrite-golds --tests-file all.tests --num-samples=10
+                                    python3 runPerformanceTests.py --overwrite-golds --tests-file all.tests --num-samples=10
                                 """
                             }
 

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -372,6 +372,7 @@ pipeline {
                             script {
                                 unstash "Stanc3Setup"
                                 unstash 'ubuntu-exe'
+                                sh "ls -lhart"
                                 sh """
                                     git clone --recursive --depth 50 https://github.com/stan-dev/performance-tests-cmdstan
                                 """
@@ -388,9 +389,11 @@ pipeline {
                                     cat shotgun_perf_all.tests >> all.tests
                                     cat all.tests
                                     echo "PRECOMPILED_HEADERS=false" >> cmdstan/make/local
+                                    pwd
                                     cd cmdstan; make clean-all; git show HEAD --stat; make -j4 build
+                                    pwd
                                     rm bin/stanc
-                                    cp "\$(readlink -f ../bin/stanc)" bin/stanc
+                                    cp ../bin/stanc bin/stanc
                                     make -j4 examples/bernoulli/bernoulli; ./bin/stanc --version; cd ..
                                     echo "STANCFLAGS += --O1" >> cmdstan/make/local
                                     CXX="clang++" python3 runPerformanceTests.py --overwrite-golds --tests-file all.tests --num-samples=10

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -388,11 +388,12 @@ pipeline {
                                     cat shotgun_perf_all.tests >> all.tests
                                     cat all.tests
                                     echo "PRECOMPILED_HEADERS=false" >> cmdstan/make/local
-                                    cd cmdstan; make clean-all; git show HEAD --stat; cd ..
-                                    alias python="python3 "
-                                    dos2unix runPerformanceTests.py
-                                    chmod +x runPerformanceTests.py
-                                    CXX="clang++" ./compare-optimizer.sh "--tests-file all.tests --num-samples=10" "--O1" "\$(readlink -f ../bin/stanc)"
+                                    cd cmdstan; make clean-all; git show HEAD --stat; make -j4 build
+                                    rm bin/stanc
+                                    cp "\$(readlink -f ../bin/stanc)" bin/stanc
+                                    make -j4 examples/bernoulli/bernoulli; ./bin/stanc --version; cd ..
+                                    echo "STANCFLAGS += --O1" >> cmdstan/make/local
+                                    CXX="clang++" python3 runPerformanceTests.py --overwrite-golds --tests-file all.tests --num-samples=10
                                 """
                             }
 

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -425,7 +425,7 @@ pipeline {
                         unstash "PerfSetup"
                         setupMakeLocal("","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
                         sh """
-                            pip install statistics --break-system-packages
+                            pip3 install statistics --break-system-packages
                             ./runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests
                         """
                         junit '*.xml'
@@ -444,7 +444,7 @@ pipeline {
                     unstash "PerfSetup"
                     setupMakeLocal("","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
                     sh """
-                        pip install statistics --break-system-packages
+                        pip3 install statistics --break-system-packages
                         ./runPerformanceTests.py --runs 2 --name=shotgun_perf --tests-file=shotgun_perf_all.tests
                     """
                 }

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -59,7 +59,7 @@ def runPerformanceTests(String testsPath, String stancFlags = ""){
         cd performance-tests-cmdstan/cmdstan
         echo 'O=0' >> make/local
         make -j${env.PARALLEL} build; cd ..
-        python3 runPerformanceTests.py -j${env.PARALLEL} --runs=2 ${testsPath}
+        python3 runPerformanceTests.py -j${env.PARALLEL} --runs=0 ${testsPath}
     """
 }
 

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -396,7 +396,7 @@ pipeline {
                                     make print-compiler-flags
                                     make -j4 examples/bernoulli/bernoulli; ./bin/stanc --version; cd ..
                                     echo "STANCFLAGS += --O1" >> cmdstan/make/local
-                                    ./runPerformanceTests.py --overwrite-golds --tests-file all.tests --num-samples=10
+                                    ./runPerformanceTests.py --overwrite-golds --tests-file all.tests --num-samples=20
                                 """
                             }
 

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -57,7 +57,7 @@ pipeline {
                 docker {
                     image 'stanorg/stanc3:staticfi'
                     label 'linux'
-                    args "--group-add=987 --group-add=988 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
+                    args "--pull always --group-add=987 --group-add=988 --entrypoint=\'\' -v /var/run/docker.sock:/var/run/docker.sock"
                 }
             }
             environment { DOCKER_TOKEN = credentials('aada4f7b-baa9-49cf-ac97-5490620fce8a') }
@@ -70,7 +70,6 @@ pipeline {
                         docker login --username stanorg --password "${DOCKER_TOKEN}"
                         docker push stanorg/ci:bleeding-edge-compilers
                     """
-
                 }
             }
             post {
@@ -116,7 +115,7 @@ pipeline {
                         docker {
                             image 'stanorg/ci:bleeding-edge-compilers'
                             label 'linux'
-                            args '--cap-add SYS_PTRACE'
+                            args '--pull always --cap-add SYS_PTRACE'
                         }
                     }
                     steps {
@@ -137,7 +136,7 @@ pipeline {
                         docker {
                             image 'stanorg/ci:bleeding-edge-compilers'
                             label 'linux'
-                            args '--cap-add SYS_PTRACE'
+                            args '--pull always --cap-add SYS_PTRACE'
                         }
                     }
                     steps {
@@ -157,7 +156,7 @@ pipeline {
                         docker {
                             image 'stanorg/ci:bleeding-edge-compilers'
                             label 'linux'
-                            args '--cap-add SYS_PTRACE'
+                            args '--pull always --cap-add SYS_PTRACE'
                         }
                     }
                     steps {

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -32,6 +32,7 @@ def setupMakeLocal(String o = "3", String cc = "clang" , String cxx = "clang++" 
             echo LDFLAGS+="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc ${ldFlags}" >> ${makeLocalPath}
         """
     }
+    sh "$CXX --version"
 }
 
 def runPerformanceTests(String testsPath, String stancFlags = "", String compiler = "clang"){

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -425,7 +425,9 @@ pipeline {
                         unstash "PerfSetup"
                         setupMakeLocal("","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
                         sh """
-                            pip3 install statistics --break-system-packages
+                            python3 -m venv .venv
+                            source .venv/bin/activate
+                            python3 -m pip install statistics
                             ./runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests
                         """
                         junit '*.xml'
@@ -444,7 +446,9 @@ pipeline {
                     unstash "PerfSetup"
                     setupMakeLocal("","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
                     sh """
-                        pip3 install statistics --break-system-packages
+                        python3 -m venv .venv
+                        source .venv/bin/activate
+                        python3 -m pip install statistics
                         ./runPerformanceTests.py --runs 2 --name=shotgun_perf --tests-file=shotgun_perf_all.tests
                     """
                 }

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -303,118 +303,118 @@ pipeline {
         //     }
         // }
 
-        stage("CmdStan & Math tests") {
-            parallel {
-                stage("Compile tests - good at O=1") {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:bleeding-edge-compilers'
-                            label 'linux'
-                            args '--pull always'
-                        }
-                    }
-                    steps {
-                        dir("${env.WORKSPACE}/compile-good-O1"){
-                            unstash "Stanc3Setup"
-                            script {
-                                runPerformanceTests("../test/integration/good", "--O1")
-                            }
+        // stage("CmdStan & Math tests") {
+        //     parallel {
+        //         stage("Compile tests - good at O=1") {
+        //             agent {
+        //                 docker {
+        //                     image 'stanorg/ci:bleeding-edge-compilers'
+        //                     label 'linux'
+        //                     args '--pull always'
+        //                 }
+        //             }
+        //             steps {
+        //                 dir("${env.WORKSPACE}/compile-good-O1"){
+        //                     unstash "Stanc3Setup"
+        //                     script {
+        //                         runPerformanceTests("../test/integration/good", "--O1")
+        //                     }
 
-                            xunit([GoogleTest(
-                                deleteOutputFiles: false,
-                                failIfNotNew: true,
-                                pattern: 'performance-tests-cmdstan/performance.xml',
-                                skipNoTestFiles: false,
-                                stopProcessingIfError: false)
-                            ])
-                        }
-                    }
-                    post { always { sh "rm -rf ${env.WORKSPACE}/compile-good-O1/*" }}
-                }
+        //                     xunit([GoogleTest(
+        //                         deleteOutputFiles: false,
+        //                         failIfNotNew: true,
+        //                         pattern: 'performance-tests-cmdstan/performance.xml',
+        //                         skipNoTestFiles: false,
+        //                         stopProcessingIfError: false)
+        //                     ])
+        //                 }
+        //             }
+        //             post { always { sh "rm -rf ${env.WORKSPACE}/compile-good-O1/*" }}
+        //         }
 
-                stage("Compile tests - example-models at O=1") {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:bleeding-edge-compilers'
-                            label 'linux'
-                            args '--pull always'
-                        }
-                    }
-                    steps {
-                        dir("${env.WORKSPACE}/compile-example-O1"){
-                            script {
-                                unstash "Stanc3Setup"
-                                runPerformanceTests("example-models", "--O1")
-                            }
+        //         stage("Compile tests - example-models at O=1") {
+        //             agent {
+        //                 docker {
+        //                     image 'stanorg/ci:bleeding-edge-compilers'
+        //                     label 'linux'
+        //                     args '--pull always'
+        //                 }
+        //             }
+        //             steps {
+        //                 dir("${env.WORKSPACE}/compile-example-O1"){
+        //                     script {
+        //                         unstash "Stanc3Setup"
+        //                         runPerformanceTests("example-models", "--O1")
+        //                     }
 
-                            xunit([GoogleTest(
-                                deleteOutputFiles: false,
-                                failIfNotNew: true,
-                                pattern: 'performance-tests-cmdstan/performance.xml',
-                                skipNoTestFiles: false,
-                                stopProcessingIfError: false)
-                            ])
-                        }
-                    }
-                    post { always { sh "rm -rf ${env.WORKSPACE}/compile-example-O1/*" }}
-                }
+        //                     xunit([GoogleTest(
+        //                         deleteOutputFiles: false,
+        //                         failIfNotNew: true,
+        //                         pattern: 'performance-tests-cmdstan/performance.xml',
+        //                         skipNoTestFiles: false,
+        //                         stopProcessingIfError: false)
+        //                     ])
+        //                 }
+        //             }
+        //             post { always { sh "rm -rf ${env.WORKSPACE}/compile-example-O1/*" }}
+        //         }
 
-                stage("Model end-to-end tests at O=1") {
-                    agent {
-                        docker {
-                            image 'stanorg/ci:bleeding-edge-compilers'
-                            label 'linux'
-                            args '--pull always'
-                        }
-                    }
-                    steps {
-                        dir("${env.WORKSPACE}/compile-end-to-end-O=1"){
-                            script {
-                                unstash "Stanc3Setup"
-                                unstash 'ubuntu-exe'
-                                sh """
-                                    git clone --recursive --depth 50 https://github.com/stan-dev/performance-tests-cmdstan
-                                """
-                                utils.checkout_pr("cmdstan", "performance-tests-cmdstan/cmdstan", params.cmdstan_pr)
-                                utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
-                                utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
-                                setupMakeLocal("","","","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
-                                sh """
-                                    cd performance-tests-cmdstan
-                                    git show HEAD --stat
-                                    echo "example-models/regression_tests/mother.stan" > all.tests
-                                    cat known_good_perf_all.tests >> all.tests
-                                    echo "" >> all.tests
-                                    cat shotgun_perf_all.tests >> all.tests
-                                    cat all.tests
-                                    echo "PRECOMPILED_HEADERS=false" >> cmdstan/make/local
-                                    pwd
-                                    cd cmdstan; make clean-all; git show HEAD --stat; make -j4 build
-                                    pwd
-                                    rm bin/stanc
-                                    cp ../../bin/stanc bin/stanc
-                                    make print-compiler-flags
-                                    make -j4 examples/bernoulli/bernoulli; ./bin/stanc --version; cd ..
-                                    echo "STANCFLAGS += --O1" >> cmdstan/make/local
-                                    ./runPerformanceTests.py --overwrite-golds --tests-file all.tests --num-samples=20
-                                """
-                            }
+        //         stage("Model end-to-end tests at O=1") {
+        //             agent {
+        //                 docker {
+        //                     image 'stanorg/ci:bleeding-edge-compilers'
+        //                     label 'linux'
+        //                     args '--pull always'
+        //                 }
+        //             }
+        //             steps {
+        //                 dir("${env.WORKSPACE}/compile-end-to-end-O=1"){
+        //                     script {
+        //                         unstash "Stanc3Setup"
+        //                         unstash 'ubuntu-exe'
+        //                         sh """
+        //                             git clone --recursive --depth 50 https://github.com/stan-dev/performance-tests-cmdstan
+        //                         """
+        //                         utils.checkout_pr("cmdstan", "performance-tests-cmdstan/cmdstan", params.cmdstan_pr)
+        //                         utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
+        //                         utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
+        //                         setupMakeLocal("","","","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
+        //                         sh """
+        //                             cd performance-tests-cmdstan
+        //                             git show HEAD --stat
+        //                             echo "example-models/regression_tests/mother.stan" > all.tests
+        //                             cat known_good_perf_all.tests >> all.tests
+        //                             echo "" >> all.tests
+        //                             cat shotgun_perf_all.tests >> all.tests
+        //                             cat all.tests
+        //                             echo "PRECOMPILED_HEADERS=false" >> cmdstan/make/local
+        //                             pwd
+        //                             cd cmdstan; make clean-all; git show HEAD --stat; make -j4 build
+        //                             pwd
+        //                             rm bin/stanc
+        //                             cp ../../bin/stanc bin/stanc
+        //                             make print-compiler-flags
+        //                             make -j4 examples/bernoulli/bernoulli; ./bin/stanc --version; cd ..
+        //                             echo "STANCFLAGS += --O1" >> cmdstan/make/local
+        //                             ./runPerformanceTests.py --overwrite-golds --tests-file all.tests --num-samples=20
+        //                         """
+        //                     }
 
-                            xunit([GoogleTest(
-                                deleteOutputFiles: false,
-                                failIfNotNew: true,
-                                pattern: 'performance-tests-cmdstan/performance.xml',
-                                skipNoTestFiles: false,
-                                stopProcessingIfError: false)
-                            ])
+        //                     xunit([GoogleTest(
+        //                         deleteOutputFiles: false,
+        //                         failIfNotNew: true,
+        //                         pattern: 'performance-tests-cmdstan/performance.xml',
+        //                         skipNoTestFiles: false,
+        //                         stopProcessingIfError: false)
+        //                     ])
 
-                            archiveArtifacts 'performance-tests-cmdstan/performance.xml'
-                        }
-                    }
-                    post { always { sh "rm -rf ${env.WORKSPACE}/compile-end-to-end-O=1/*" }}
-                }
-            }
-        }
+        //                     archiveArtifacts 'performance-tests-cmdstan/performance.xml'
+        //                 }
+        //             }
+        //             post { always { sh "rm -rf ${env.WORKSPACE}/compile-end-to-end-O=1/*" }}
+        //         }
+        //     }
+        // }
 
         stage('CmdStan Perf Tests') {
             parallel {
@@ -424,7 +424,10 @@ pipeline {
                     steps {
                         unstash "PerfSetup"
                         setupMakeLocal("","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
-                        sh "./runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests"
+                        sh """
+                            pip install statistics
+                            ./runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests
+                        """
                         junit '*.xml'
                         archiveArtifacts '*.xml'
                 }
@@ -440,7 +443,10 @@ pipeline {
                 steps {
                     unstash "PerfSetup"
                     setupMakeLocal("","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
-                    sh "./runPerformanceTests.py --runs 2 --name=shotgun_perf --tests-file=shotgun_perf_all.tests "
+                    sh """
+                        pip install statistics
+                        ./runPerformanceTests.py --runs 2 --name=shotgun_perf --tests-file=shotgun_perf_all.tests
+                    """
                 }
             }
             }

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -34,7 +34,7 @@ def setupMakeLocal(String o = "3", String cc = "clang" , String cxx = "clang++" 
     }
     else {
         sh """
-            echo LDFLAGS+="${ldFlags}" >> ${makeLocalPath}
+            echo LDFLAGS+="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc ${ldFlags}" >> ${makeLocalPath}
         """
     }
     sh "${cxx} --version"

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -20,8 +20,8 @@ def runTests(String testPath, boolean jumbo = false) {
 
 def setupMakeLocal(String o = "", String cc = "" , String cxx = "" , String cFlags = "", String cppFlags = "", String cxxFlags = "", String ldFlags = "", String makeLocalPath = "make/local") {
     // When ready, change O=3
+    //         echo O="${o}" >> ${makeLocalPath}
     sh """
-        echo O="0 ${o}" >> ${makeLocalPath}
         echo CC="clang ${cc}" >> ${makeLocalPath}
         echo CXX="clang++ ${cxx}" >> ${makeLocalPath}
         echo CFLAGS+="-stdlib=libc++ ${cFlags}" >> ${makeLocalPath}
@@ -42,7 +42,7 @@ def runPerformanceTests(String testsPath, String stancFlags = ""){
     utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
     utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
 
-    setupMakeLocal("","","","","","", "-ltbb", "performance-tests-cmdstan/cmdstan/make/local")
+    setupMakeLocal("0","","","","","", "-ltbb", "performance-tests-cmdstan/cmdstan/make/local")
 
     sh """
         cd performance-tests-cmdstan
@@ -378,7 +378,7 @@ pipeline {
         //                         utils.checkout_pr("cmdstan", "performance-tests-cmdstan/cmdstan", params.cmdstan_pr)
         //                         utils.checkout_pr("stan", "performance-tests-cmdstan/cmdstan/stan", params.stan_pr)
         //                         utils.checkout_pr("math", "performance-tests-cmdstan/cmdstan/stan/lib/stan_math", params.math_pr)
-        //                         setupMakeLocal("","","","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
+        //                         setupMakeLocal("0","","","","","-march=core2", "", "performance-tests-cmdstan/cmdstan/make/local")
         //                         sh """
         //                             cd performance-tests-cmdstan
         //                             git show HEAD --stat
@@ -423,7 +423,7 @@ pipeline {
                     agent { label 'osx && intel' }
                     steps {
                         unstash "PerfSetup"
-                        setupMakeLocal("","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
+                        setupMakeLocal("0","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
                         sh """
                             python3 -m venv .venv
                             source .venv/bin/activate
@@ -444,7 +444,7 @@ pipeline {
                 }
                 steps {
                     unstash "PerfSetup"
-                    setupMakeLocal("","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
+                    setupMakeLocal("0","","","","","-march=core2 \n${stanc3_bin_url()}", "", "cmdstan/make/local")
                     sh """
                         python3 -m venv .venv
                         source .venv/bin/activate

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -123,13 +123,13 @@ pipeline {
 
         stage('Pull latest docker image') {
             parallel {
-                stage('Rev/Fwd Unit Tests') {
+                stage('Pull on v100') {
                     agent { label 'linux && v100' }
                     steps {
                         sh "docker pull stanorg/ci:bleeding-edge-compilers"
                     }
                 }
-                stage('Mix Unit Tests') {
+                stage('Pull on k40') {
                     agent { label 'linux && k40' }
                     steps {
                         sh "docker pull stanorg/ci:bleeding-edge-compilers"

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -519,8 +519,8 @@ pipeline {
                 recordIssues enabledForFailure: false, tool: clang()
             }
         }
-        // success { script { utils.mailBuildResults("SUCCESSFUL") } }
-        // unstable { script { utils.mailBuildResults("UNSTABLE") } }
-        // failure { script { utils.mailBuildResults("FAILURE") } }
+        success { script { utils.mailBuildResults("SUCCESSFUL") } }
+        unstable { script { utils.mailBuildResults("UNSTABLE") } }
+        failure { script { utils.mailBuildResults("FAILURE") } }
     }
 }

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -32,6 +32,11 @@ def setupMakeLocal(String o = "3", String cc = "clang" , String cxx = "clang++" 
             echo LDFLAGS+="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc ${ldFlags}" >> ${makeLocalPath}
         """
     }
+    else {
+        sh """
+            echo CFLAGS+="-stdlib=libstdc++" >> ${makeLocalPath}
+        """
+    }
     sh "${cxx} --version"
 }
 

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -32,11 +32,6 @@ def setupMakeLocal(String o = "3", String cc = "clang" , String cxx = "clang++" 
             echo LDFLAGS+="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc ${ldFlags}" >> ${makeLocalPath}
         """
     }
-    else {
-        sh """
-            echo LDFLAGS+="-L/usr/local/lib -Wl,-R/usr/local/lib -I/usr/local/include/c++/v1  -L/usr/local/lib -Wl,-rpath,/usr/local/lib -lc++ -lc++abi -lm -lc -lgcc_s -lgcc ${ldFlags}" >> ${makeLocalPath}
-        """
-    }
     sh "${cxx} --version"
 }
 

--- a/Jenkinsfile-bleeding-edge-monthly
+++ b/Jenkinsfile-bleeding-edge-monthly
@@ -24,7 +24,7 @@ def setupMakeLocal(String o = "3", String cc = "clang" , String cxx = "clang++" 
         echo CC="${cc}" >> ${makeLocalPath}
         echo CXX="${cxx}" >> ${makeLocalPath}
     """
-    if (cc = "clang") {
+    if (cc == "clang") {
         sh """
             echo CFLAGS+="-stdlib=libc++ ${cFlags}" >> ${makeLocalPath}
             echo CPPFLAGS+="-nostdinc++ -nodefaultlibs -I/usr/local/include/c++/v1 ${cppFlags}" >> ${makeLocalPath}

--- a/docker/bleeding-edge-compilers/Dockerfile
+++ b/docker/bleeding-edge-compilers/Dockerfile
@@ -62,3 +62,14 @@ RUN git clone https://github.com/llvm/llvm-project.git && \
 
 # Update LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH="/usr/local/lib:${PATH}"
+
+# Install pyenv
+RUN curl https://pyenv.run | bash
+
+RUN echo "export PYENV_ROOT=\"/home/jenkins/.pyenv\"" > ~/.bash_profile
+RUN echo "command -v pyenv >/dev/null || export PATH=\"/home/jenkins/.pyenv/bin:$PATH\"" >> ~/.bash_profile
+RUN echo "eval \"$(pyenv init --path)\"" >> ~/.bash_profile
+
+RUN PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.8.10
+RUN pyenv global 3.8.10
+ENV PYTHONHOME="/home/jenkins/.pyenv/versions/3.8.10"

--- a/docker/bleeding-edge-compilers/Dockerfile
+++ b/docker/bleeding-edge-compilers/Dockerfile
@@ -66,6 +66,8 @@ ENV LD_LIBRARY_PATH="/usr/local/lib:${PATH}"
 # Install pyenv
 RUN curl https://pyenv.run | bash
 
+ENV PATH="/home/jenkins/.pyenv/bin:$PATH"
+
 RUN echo "export PYENV_ROOT=\"/home/jenkins/.pyenv\"" > ~/.bash_profile
 RUN echo "command -v pyenv >/dev/null || export PATH=\"/home/jenkins/.pyenv/bin:$PATH\"" >> ~/.bash_profile
 RUN echo "eval \"$(pyenv init --path)\"" >> ~/.bash_profile

--- a/docker/bleeding-edge-compilers/Dockerfile
+++ b/docker/bleeding-edge-compilers/Dockerfile
@@ -64,5 +64,5 @@ ENV LD_LIBRARY_PATH="/usr/local/lib:${PATH}"
 RUN curl https://pyenv.run | bash
 
 # Add pyenv to PATH
-ENV PATH="$HOME/.pyenv/bin:$PATH"
+ENV PATH="/home/jenkins/.pyenv/bin:${PATH}"
 RUN eval "$(pyenv init --path)" && eval "$(pyenv virtualenv-init -)"

--- a/docker/bleeding-edge-compilers/Dockerfile
+++ b/docker/bleeding-edge-compilers/Dockerfile
@@ -9,9 +9,12 @@ ARG PGID
 ENV TZ="America/New_York"
 
 # Install OS depdencies
-RUN apt-get update -y && apt-get install wget git curl xz-utils build-essential libmpc-dev jq gcc-multilib software-properties-common cmake make ninja-build sudo dos2unix python3-pip \
+RUN apt-get update -y && apt-get install wget git curl xz-utils build-essential libmpc-dev jq gcc-multilib software-properties-common cmake make ninja-build sudo dos2unix python3 python3-pip \
     libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget  \
     libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev -y
+
+RUN ln -sf python3 /usr/bin/python
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
 # Install latest gcc, g++ from ubuntu toolchain ppa
 # https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test
@@ -59,10 +62,3 @@ RUN git clone https://github.com/llvm/llvm-project.git && \
 
 # Update LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH="/usr/local/lib:${PATH}"
-
-# Install pyenv
-RUN curl https://pyenv.run | bash
-
-# Add pyenv to PATH
-ENV PATH="/home/jenkins/.pyenv/bin:${PATH}"
-RUN eval "$(pyenv init --path)" && eval "$(pyenv virtualenv-init -)"

--- a/docker/bleeding-edge-compilers/Dockerfile
+++ b/docker/bleeding-edge-compilers/Dockerfile
@@ -43,7 +43,6 @@ RUN git clone --depth=1 https://github.com/llvm/llvm-project.git && \
     mkdir build && cd build && \
     cmake -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles" ../llvm && \
     make clang && \
-    make check-clang && \
     clang --help && \
     cd .. && rm -rf build && mkdir build && cd build && \
     cmake -G Ninja -S ../runtimes -B build -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind;third-party;test-suite" -D CMAKE_CXX_COMPILER=clang++ -D CMAKE_C_COMPILER=clang && \

--- a/docker/bleeding-edge-compilers/Dockerfile
+++ b/docker/bleeding-edge-compilers/Dockerfile
@@ -37,22 +37,15 @@ RUN chown -f -R jenkins:jenkins /etc || true
 USER jenkins
 WORKDIR /home/jenkins
 
-# Download and install the latest version of LLVM and CLANG
-RUN LATEST_RELEASE_ARCHIVE=$(curl -s https://api.github.com/repos/llvm/llvm-project/releases/latest | grep browser_download_url | cut -d\" -f4 | egrep 'clang%2Bllvm-(.*?)-x86_64-linux-gnu-ubuntu-22.04.tar.xz') && \
-    wget -O llvm-clang-latest.tar.xz $LATEST_RELEASE_ARCHIVE && \
-    tar -xvf llvm-clang-latest.tar.xz && mv "clang+llvm"* llvm-clang-latest && \
-    LATEST_RELEASE=$(echo $LATEST_RELEASE_ARCHIVE | grep -Eo '[0-9][0-9]\.[0-9]\.[0-9]+' | head -1) && \
-    major=$(echo $LATEST_RELEASE | cut -d. -f1) && \
-    echo "${major}" > clang-major-version.txt && cat clang-major-version.txt && \
-    rm -rf llvm-clang-latest.tar.xz 
-
-# Add latest clang,llvm to PATH
-ENV PATH="/home/jenkins/llvm-clang-latest/bin:${PATH}"
-
 # Download the source code, build & install libcxx
-RUN git clone https://github.com/llvm/llvm-project.git && \
+RUN git clone --depth=1 https://github.com/llvm/llvm-project.git && \
     cd llvm-project && \
     mkdir build && cd build && \
+    cmake -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles" ../llvm && \
+    make clang && \
+    make check-clang && \
+    clang --help && \
+    cd .. && rm -rf build && mkdir build && cd build && \
     cmake -G Ninja -S ../runtimes -B build -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind;third-party;test-suite" -D CMAKE_CXX_COMPILER=clang++ -D CMAKE_C_COMPILER=clang && \
     ninja -C build cxx cxxabi unwind && \
     ninja -C build check-cxx check-cxxabi check-unwind && \
@@ -63,23 +56,5 @@ RUN git clone https://github.com/llvm/llvm-project.git && \
 # Update LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH="/usr/local/lib:${PATH}"
 
-# # Install pyenv
-# RUN curl https://pyenv.run | bash
-
-# ENV PATH="/home/jenkins/.pyenv/bin:$PATH"
-
-# RUN echo "export PYENV_ROOT=\"/home/jenkins/.pyenv\"" > ~/.bash_profile
-# RUN echo "command -v pyenv >/dev/null || export PATH=\"/home/jenkins/.pyenv/bin:$PATH\"" >> ~/.bash_profile
-# RUN echo "eval \"$(pyenv init --path)\"" >> ~/.bash_profile
-
-# RUN PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.8.10
-# RUN pyenv global 3.8.10
-# ENV PYTHONHOME="/home/jenkins/.pyenv/versions/3.8.10:/home/jenkins/.pyenv/versions/3.8.10"
-# ENV PYTHONPATH="/home/jenkins/.pyenv/versions/3.8.10"
-
-#   sys.path = [
-#     '/home/jenkins/.pyenv/versions/3.8.10',
-#     '/home/jenkins/.pyenv/versions/3.8.10/lib/python311.zip',
-#     '/home/jenkins/.pyenv/versions/3.8.10/lib/python3.11',
-#     '/home/jenkins/.pyenv/versions/3.8.10/lib/python3.11/lib-dynload',
-#   ]
+# Add latest clang,llvm to PATH
+ENV PATH="/home/jenkins/llvm-clang-latest/bin:${PATH}"

--- a/docker/bleeding-edge-compilers/Dockerfile
+++ b/docker/bleeding-edge-compilers/Dockerfile
@@ -7,7 +7,7 @@ ARG PUID
 ARG PGID
 
 # Install OS depdencies
-RUN apt-get update -y && apt-get install wget git curl xz-utils build-essential libmpc-dev jq gcc-multilib software-properties-common cmake ninja-build sudo dos2unix -y
+RUN apt-get update -y && apt-get install wget git curl xz-utils build-essential libmpc-dev jq gcc-multilib software-properties-common cmake ninja-build sudo dos2unix python3-pip -y
 
 # Install latest gcc, g++ from ubuntu toolchain ppa
 # https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test

--- a/docker/bleeding-edge-compilers/Dockerfile
+++ b/docker/bleeding-edge-compilers/Dockerfile
@@ -7,7 +7,7 @@ ARG PUID
 ARG PGID
 
 # Install OS depdencies
-RUN apt-get update -y && apt-get install wget git curl xz-utils build-essential libmpc-dev jq gcc-multilib software-properties-common cmake ninja-build sudo -y
+RUN apt-get update -y && apt-get install wget git curl xz-utils build-essential libmpc-dev jq gcc-multilib software-properties-common cmake ninja-build sudo dos2unix -y
 
 # Install latest gcc, g++ from ubuntu toolchain ppa
 # https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test

--- a/docker/bleeding-edge-compilers/Dockerfile
+++ b/docker/bleeding-edge-compilers/Dockerfile
@@ -37,20 +37,23 @@ RUN chown -f -R jenkins:jenkins /etc || true
 USER jenkins
 WORKDIR /home/jenkins
 
+ENV clangbuild=/home/jenkins/llvm-project/build
+ENV PATH=$clangbuild/bin:$PATH
+ENV LD_LIBRARY_PATH=$clangbuild/lib:$LD_LIBRARY_PATH
+
 # Download the source code, build & install libcxx
 RUN git clone --depth=1 https://github.com/llvm/llvm-project.git && \
     cd llvm-project && \
     mkdir build && cd build && \
     cmake -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles" ../llvm && \
-    make clang && \
+    make clang -j8 && \
     clang --help && \
-    cd .. && rm -rf build && mkdir build && cd build && \
     cmake -G Ninja -S ../runtimes -B build -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind;third-party;test-suite" -D CMAKE_CXX_COMPILER=clang++ -D CMAKE_C_COMPILER=clang && \
     ninja -C build cxx cxxabi unwind && \
     ninja -C build check-cxx check-cxxabi check-unwind && \
     ninja -C build install-cxx install-cxxabi install-unwind && \
     ldconfig /usr/local/lib && \
-    cd ../../ && rm -rf llvm-project
+    cd ../../
 
 # Update LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH="/usr/local/lib:${PATH}"

--- a/docker/bleeding-edge-compilers/Dockerfile
+++ b/docker/bleeding-edge-compilers/Dockerfile
@@ -42,7 +42,8 @@ ENV PATH=$clangbuild/bin:$PATH
 ENV LD_LIBRARY_PATH=$clangbuild/lib:$LD_LIBRARY_PATH
 
 # Download the source code, build & install libcxx
-RUN git clone --depth=1 https://github.com/llvm/llvm-project.git && \
+RUN LATEST_RELEASE_VERSION=$(curl https://api.github.com/repos/llvm/llvm-project/tags | jq '.[]|select(.name | startswith("llvmorg-"))' | jq '.name' | grep -Eo '[0-9][0-9]\.[0-9]\.[0-9]+' | head -1 ) && \
+    git clone -b "llvmorg-${LATEST_RELEASE_VERSION}" --depth=1 https://github.com/llvm/llvm-project.git && \
     cd llvm-project && \
     mkdir build && cd build && \
     cmake -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles" ../llvm && \

--- a/docker/bleeding-edge-compilers/Dockerfile
+++ b/docker/bleeding-edge-compilers/Dockerfile
@@ -24,9 +24,6 @@ RUN LATEST_RELEASE=$(curl https://api.github.com/repos/gcc-mirror/gcc/tags | jq 
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-"${major}" "${major}" && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-"${major}" "${major}"
 
-# Install pyenv
-RUN curl https://pyenv.run | bash
-
 # Add Jenkins user and group
 RUN addgroup -gid ${PGID} jenkins
 RUN adduser --disabled-password --gecos '' --ingroup jenkins --uid ${PUID} jenkins
@@ -62,3 +59,10 @@ RUN git clone https://github.com/llvm/llvm-project.git && \
 
 # Update LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH="/usr/local/lib:${PATH}"
+
+# Install pyenv
+RUN curl https://pyenv.run | bash
+
+# Add pyenv to PATH
+ENV PATH="$HOME/.pyenv/bin:$PATH"
+RUN eval "$(pyenv init --path)" && eval "$(pyenv virtualenv-init -)"

--- a/docker/bleeding-edge-compilers/Dockerfile
+++ b/docker/bleeding-edge-compilers/Dockerfile
@@ -6,8 +6,12 @@ USER root
 ARG PUID
 ARG PGID
 
+ENV TZ="America/New_York"
+
 # Install OS depdencies
-RUN apt-get update -y && apt-get install wget git curl xz-utils build-essential libmpc-dev jq gcc-multilib software-properties-common cmake ninja-build sudo dos2unix python3-pip -y
+RUN apt-get update -y && apt-get install wget git curl xz-utils build-essential libmpc-dev jq gcc-multilib software-properties-common cmake make ninja-build sudo dos2unix python3-pip \
+    libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget  \
+    libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev -y
 
 # Install latest gcc, g++ from ubuntu toolchain ppa
 # https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test
@@ -19,6 +23,9 @@ RUN LATEST_RELEASE=$(curl https://api.github.com/repos/gcc-mirror/gcc/tags | jq 
     # Set gcc and g++ to latest version
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-"${major}" "${major}" && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-"${major}" "${major}"
+
+# Install pyenv
+RUN curl https://pyenv.run | bash
 
 # Add Jenkins user and group
 RUN addgroup -gid ${PGID} jenkins

--- a/docker/bleeding-edge-compilers/Dockerfile
+++ b/docker/bleeding-edge-compilers/Dockerfile
@@ -63,15 +63,23 @@ RUN git clone https://github.com/llvm/llvm-project.git && \
 # Update LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH="/usr/local/lib:${PATH}"
 
-# Install pyenv
-RUN curl https://pyenv.run | bash
+# # Install pyenv
+# RUN curl https://pyenv.run | bash
 
-ENV PATH="/home/jenkins/.pyenv/bin:$PATH"
+# ENV PATH="/home/jenkins/.pyenv/bin:$PATH"
 
-RUN echo "export PYENV_ROOT=\"/home/jenkins/.pyenv\"" > ~/.bash_profile
-RUN echo "command -v pyenv >/dev/null || export PATH=\"/home/jenkins/.pyenv/bin:$PATH\"" >> ~/.bash_profile
-RUN echo "eval \"$(pyenv init --path)\"" >> ~/.bash_profile
+# RUN echo "export PYENV_ROOT=\"/home/jenkins/.pyenv\"" > ~/.bash_profile
+# RUN echo "command -v pyenv >/dev/null || export PATH=\"/home/jenkins/.pyenv/bin:$PATH\"" >> ~/.bash_profile
+# RUN echo "eval \"$(pyenv init --path)\"" >> ~/.bash_profile
 
-RUN PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.8.10
-RUN pyenv global 3.8.10
-ENV PYTHONHOME="/home/jenkins/.pyenv/versions/3.8.10"
+# RUN PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.8.10
+# RUN pyenv global 3.8.10
+# ENV PYTHONHOME="/home/jenkins/.pyenv/versions/3.8.10:/home/jenkins/.pyenv/versions/3.8.10"
+# ENV PYTHONPATH="/home/jenkins/.pyenv/versions/3.8.10"
+
+#   sys.path = [
+#     '/home/jenkins/.pyenv/versions/3.8.10',
+#     '/home/jenkins/.pyenv/versions/3.8.10/lib/python311.zip',
+#     '/home/jenkins/.pyenv/versions/3.8.10/lib/python3.11',
+#     '/home/jenkins/.pyenv/versions/3.8.10/lib/python3.11/lib-dynload',
+#   ]

--- a/docker/bleeding-edge-compilers/Dockerfile
+++ b/docker/bleeding-edge-compilers/Dockerfile
@@ -9,7 +9,7 @@ ARG PGID
 ENV TZ="America/New_York"
 
 # Install OS depdencies
-RUN apt-get update -y && apt-get install wget git curl xz-utils build-essential libmpc-dev jq gcc-multilib software-properties-common cmake make ninja-build sudo dos2unix python3 python3-pip \
+RUN apt-get update -y && apt-get install wget git curl xz-utils build-essential libmpc-dev jq gcc-multilib software-properties-common cmake make ninja-build sudo dos2unix python3 python3-pip python3-venv \
     libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget  \
     libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev -y
 


### PR DESCRIPTION
See: https://github.com/stan-dev/ci-scripts/issues/26

Adding a new Monthly job for bleeding edge compilers against math.
The pipeline will take care of building a Docker image that will install the latest clang ( from Github releases ) and gcc from ppa `ppa:ubuntu-toolchain-r/test` for that we are using `ubuntu:lunar` base image.  This is a much faster and simpler way than installing gcc from sources.

Dockerfile will make sure to add clang to path:
```
ENV PATH="${PATH}:/tmp/llvm-clang-latest/bin"
```
And update gcc/g++ binaries to the latest version:
```
update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-"${major}" "${major}" && \
update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-"${major}" "${major}"
```

Dockerfile will write the version of `clang` and `gcc` to a file in `/tmp` so we can read it later on if needed during CI.
```
echo "${major}" > clang-major-version.txt 
echo "${major}" > gcc-major-version.txt
```
Example: `export CLANG_CXX="clang++-\$(cat /tmp/clang-major-version.txt)"`

