### PR TITLE
updating doxygen to 1.9.7

### DIFF
--- a/docker/ci/Dockerfile-gpu
+++ b/docker/ci/Dockerfile-gpu
@@ -25,9 +25,15 @@ ENV INTEL_SDK_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/vc
 RUN apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/* && update-ca-certificates && apt-get update -y
 RUN apt-get install nano alien bash dpkg git make curl wget cmake autoconf vim automake python3 python3-pip -y
 RUN apt-get install nvidia-driver-460 cuda-drivers-460 intel-opencl-icd nvidia-cuda-toolkit opencl-headers clinfo -y
-RUN apt-get install doxygen binutils clang-format clang-${CLANG_VERSION} clang++-${CLANG_VERSION} gcc lld-${LLD_VERSION} lld -y
+RUN apt-get install binutils clang-format clang-${CLANG_VERSION} clang++-${CLANG_VERSION} gcc lld-${LLD_VERSION} lld -y
 RUN apt-get install libxml2-dev linux-headers-generic libopenmpi-dev libxslt-dev mpi mpich -y
 RUN ln -sf python3 /usr/bin/python
+
+# Install doxygen
+RUN wget https://www.doxygen.nl/files/doxygen-1.9.7.linux.bin.tar.gz \
+    && tar -xzvf doxygen-1.9.7.linux.bin.tar.gz \
+    && cp doxygen-1.9.7/bin/doxygen /bin/
+RUN chmod +x /bin/doxygen
 
 # Setup pip and requirements
 RUN pip3 install --no-cache --upgrade pip setuptools


### PR DESCRIPTION
This PR updates doxygen to 1.9.7. The current `apt-get install doxygen` installs 1.8.17, which was released in Dec 2019. 

This is for developers generating documentation in the math library and it doesn't have a user-facing component to it, so it should be safe to do. Doxygen 1.9.7 is available as a binary for linux, windows, and mac.