### PR TITLE
Add update script for rstan submodule

### DIFF
--- a/jenkins/create-rstan-pull-request.sh
+++ b/jenkins/create-rstan-pull-request.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+trap 'abort' 0
+
+set -e
+
+git checkout develop
+git pull origin
+git submodule update --init --recursive
+pushd StanHeaders/inst/include/upstream > /dev/null
+git checkout develop
+git pull origin
+popd > /dev/null
+git submodule update --init --recursive
+
+original_commit_hash=$(cd StanHeaders/inst/include/upstream && git rev-parse --short HEAD)
+stan_commit_hash=$(cd StanHeaders/inst/include/upstream && git rev-parse --short origin/develop)
+
+
+if [ "$original_commit_hash" == "$stan_commit_hash" ]; then
+  echo "------------------------------------------------------------"
+  echo ""
+  echo "  No need to update. "
+  echo "  Submodule at: ${original_commit_hash}."
+  echo "  Update to:    ${stan_commit_hash}."
+  echo ""
+  echo "------------------------------------------------------------"
+  echo ""
+  trap : 0
+  exit 0
+fi
+
+pushd StanHeaders/inst/include/upstream > /dev/null
+git checkout ${stan_commit_hash}
+popd > /dev/null
+git add StanHeaders/inst/include/upstream
+git commit -m "Updates the Stan submodule to ${stan_commit_hash}." stan
+git push origin develop
+
+trap : 0
+
+echo "------------------------------------------------------------"
+echo ""
+echo "  Success updating stan submodule to ${stan_commit_hash}"
+echo ""
+echo "------------------------------------------------------------"
+echo ""
+
+exit 0


### PR DESCRIPTION
Now that rstan's `develop` branch is [up to date](https://github.com/stan-dev/rstan/pull/1148), we can start triggering the automatic update of the stan submodule

From what I can see in the [stan Jenkinsfile](https://github.com/stan-dev/stan/blob/108daa93b6dd0d7b351864494bdcd5a255f6a765/Jenkinsfile#L518) I need to add this pull request script for rstan, which would be called by `utils.updateUpstream(env,'rstan')`, but let me know if I'm in the wrong place!

I also haven't tested this (since I'm not sure how), but I've just taken the existing `cmdstan` script and changed the file path - so please check if I've missed anything!