### PR TITLE
Fix incorrect folder name in rstan submodule update script

### DIFF
--- a/jenkins/create-rstan-pull-request.sh
+++ b/jenkins/create-rstan-pull-request.sh
@@ -34,7 +34,7 @@ pushd StanHeaders/inst/include/upstream > /dev/null
 git checkout ${stan_commit_hash}
 popd > /dev/null
 git add StanHeaders/inst/include/upstream
-git commit -m "Updates the Stan submodule to ${stan_commit_hash}." stan
+git commit -m "Updates the Stan submodule to ${stan_commit_hash}." StanHeaders/inst/include/upstream
 git push origin develop
 
 trap : 0


### PR DESCRIPTION
The automated updating of the Stan submodule in `rstan` is failing since I missed updating one of the folder names